### PR TITLE
add .jekyll-cache/ to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 __pycache__
 _site
 .Rproj.user
+.jekyll-cache/


### PR DESCRIPTION
When `jekyll serve` run, `.jekyll-cache/` is created. Untrack this file.

Edit: It happens to me since my Jekyll is version 4.0.1
reference: https://forestry.io/blog/how-i-reduced-my-jekyll-build-time-by-61/