### PR TITLE
Line breaks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 *.pyc
 *~
 .DS_Store
+.idea
 .ipynb_checkpoints
 .sass-cache
 __pycache__

--- a/_episodes/01-package-setup.md
+++ b/_episodes/01-package-setup.md
@@ -14,25 +14,38 @@ keypoints:
 - "You can use the CMS CookieCutter to quickly create the layout for a Python package"
 ---
 
-For this workshop, we are going to create a Python package that performs analysis and creates visualizations for molecules. We will start from a Jupyter notebook which has some functions and analysis, which you should download on the [setup]. 
+For this workshop, we are going to create a Python package that performs analysis and creates visualizations for
+molecules. We will start from a Jupyter notebook which has some functions and analysis, which you should download on
+the [setup].
 
-The idea is that we would like to take this Jupyter notebook and convert the functions we have created into a Python package. That way, if anyone (a labmate, for example) would like to use our functions, they can do so by installing the package and importing it into their own scripts.
+The idea is that we would like to take this Jupyter notebook and convert the functions we have created into a Python
+package. That way, if anyone (a labmate, for example) would like to use our functions, they can do so by installing the
+package and importing it into their own scripts.
 
-To start, we will first use a tool called [CookieCutter](https://cookiecutter.readthedocs.io/en/latest/) which will set up a Python package structure and several tools we will use during the workshop.
+To start, we will first use a tool called [CookieCutter](https://cookiecutter.readthedocs.io/en/latest/) which will set
+up a Python package structure and several tools we will use during the workshop.
 
 ## Examples of Python package structure
-If you look at the GitHub repositories for several large Python packages such as [numpy], [scipy], or [scikit-learn], you will notice a lot of similarities between the directory layouts of these projects.
+
+If you look at the GitHub repositories for several large Python packages such as [numpy], [scipy], or [scikit-learn],
+you will notice a lot of similarities between the directory layouts of these projects.
 
 Having a similar way to lay out Python packages allows people to more easily understand and contribute to your code.
 
 ## Creating a Python package using CookieCutter
-To create a skeletal structure for our project, we will use the MolSSI Computational Molecular Science (CMS) CookieCutter. The [CMS CookieCutter] is a special cookiecutter created specifically by MolSSI to use the tools and services we recommend in developing a Python project.
 
-CookieCutter will not only create our directory layout, but will also set up many tools we will use including testing, continuous integration, documentation, and version control using git. We will discuss what all of these are later in the workshop.
+To create a skeletal structure for our project, we will use the MolSSI Computational Molecular Science (CMS)
+CookieCutter. The [CMS CookieCutter] is a special cookiecutter created specifically by MolSSI to use the tools and
+services we recommend in developing a Python project.
+
+CookieCutter will not only create our directory layout, but will also set up many tools we will use including testing,
+continuous integration, documentation, and version control using git. We will discuss what all of these are later in the
+workshop.
 
 ### Obtaining CookieCutter
 
-You should have the general CookieCutter installed, according to the directions given in the [setup] portion of this workshop. If you do not, please navigate to [setup] and follow the instructions given there.
+You should have the general CookieCutter installed, according to the directions given in the [setup] portion of this
+workshop. If you do not, please navigate to [setup] and follow the instructions given there.
 
 ### Running CookieCutter
 To run the [CMS CookieCutter], navigate to the directory where you would like to start your project, and type:
@@ -42,12 +55,17 @@ $ cookiecutter gh:molssi/cookiecutter-cms
 ~~~
 {: .language-bash}
 
-This command runs the cookiecutter software (`cookiecutter` in the command) and tells cookiecutter to look at GitHub (`gh`) n the repository under `molssi/cookiecutter-cms`. This repository contains a template which cookiecutter uses to create your project, once you have provided some starting information.
+This command runs the cookiecutter software (`cookiecutter` in the command) and tells cookiecutter to look at
+GitHub (`gh`) n the repository under `molssi/cookiecutter-cms`. This repository contains a template which cookiecutter
+uses to create your project, once you have provided some starting information.
 
-You will see an interactive prompt which asks questions about your project. Here, the prompt is given first, followed by the default value in square brackets. The first question will be on your project name. You have very cleverly decided to give it the name `molecool` (it's like molecule, but with `cool` instead, because of your cool visualizations - get it?)
+You will see an interactive prompt which asks questions about your project. Here, the prompt is given first, followed by
+the default value in square brackets. The first question will be on your project name. You have very cleverly decided to
+give it the name `molecool` (it's like molecule, but with `cool` instead, because of your cool visualizations - get it?)
 
-Answer the questions according to the following.
-If nothing is given after the colon (`:`), hit enter to use the default value.
+Answer the questions according to the following. If nothing is given after the colon (`:`), hit enter to use the default
+value.
+
 ~~~
 project_name [ProjectName]: molecool
 repo_name [molecool]:
@@ -78,24 +96,45 @@ Choose from 1, 2 (1, 2) [1]:
 
 ### About these decisions
 
-The first two questions are for the project and repository name. The project name is the name of the project, while the repo name is the name of the folder that cookiecutter will create. Usually, you will leave these two to be the same thing. The `repo_name` is the name which you will use to import the package you eventually create, and because of that has some rules. The `repo_name` must be a valid Python module name and cannot contain spaces.
+The first two questions are for the project and repository name. The project name is the name of the project, while the
+repo name is the name of the folder that cookiecutter will create. Usually, you will leave these two to be the same
+thing. The `repo_name` is the name which you will use to import the package you eventually create, and because of that
+has some rules. The `repo_name` must be a valid Python module name and cannot contain spaces.
 
-The next choice is about the first module name. Modules are the `.py` files which contain python code. The default for this is the `repo_name`, but we will change this to avoid confusion (the module `molecool.py` in a folder named `molecool` in a folder named `molecool`??). For now, we'll just name our first module `functions`, and this is where we will put all of our starting functions.
+The next choice is about the first module name. Modules are the `.py` files which contain python code. The default for
+this is the `repo_name`, but we will change this to avoid confusion (the module `molecool.py` in a folder
+named `molecool` in a folder named `molecool`??). For now, we'll just name our first module `functions`, and this is
+where we will put all of our starting functions.
 
-Another thing the CookieCutter checks for is your email address. Be sure to provide a valid email address to the cookiecutter (it must have an `@` symbol followed by a domain name, or the cookiecutter will fail.). Note that your email address is not recorded or kept by the software. Your email is asked for insertion into created files so that people using your software will have contact information for you. 
+Another thing the CookieCutter checks for is your email address. Be sure to provide a valid email address to the
+cookiecutter (it must have an `@` symbol followed by a domain name, or the cookiecutter will fail.). Note that your
+email address is not recorded or kept by the software. Your email is asked for insertion into created files so that
+people using your software will have contact information for you.
 
 #### License Choice
-Choosing which license to use is often confusing for new developers. The MIT license (option 1) is a very common license and the default on GitHub. It allows for anyone to use, modify, or redistribute your work with no restrictions (and also no warranty).
 
-Here, we have chosen the `BSD-3-Clause`. The `BSD-3-Clause` license is an open-source, permissive license (meaning that few requirements are placed on developers of derivative works), similar to the MIT license. However, it adds a copyright notice with your name and requires redistributors of the code to keep the notice. It also prohibits others from using the name of the project or its contributors to promote derived products without written consent.
+Choosing which license to use is often confusing for new developers. The MIT license (option 1) is a very common license
+and the default on GitHub. It allows for anyone to use, modify, or redistribute your work with no restrictions (and also
+no warranty).
 
-You can see more detailed information on each license at [choosealicense.com](https://choosealicense.com) or by clicking the links below:
+Here, we have chosen the `BSD-3-Clause`. The `BSD-3-Clause` license is an open-source, permissive license (meaning that
+few requirements are placed on developers of derivative works), similar to the MIT license. However, it adds a copyright
+notice with your name and requires redistributors of the code to keep the notice. It also prohibits others from using
+the name of the project or its contributors to promote derived products without written consent.
+
+You can see more detailed information on each license at [choosealicense.com](https://choosealicense.com) or by clicking
+the links below:
+
 1. [MIT License](https://choosealicense.com/licenses/mit/)
 1. [BSD-3-Clause](https://choosealicense.com/licenses/bsd-3-clause/)
 1. [LGPLv3](https://choosealicense.com/licenses/gpl-3.0/)
-1. Not Open Source - In this case, the cookiecutter will not generate a license. You can add a custom license, or choose to not add a license. If there is no license in a repository, you should assume that the project is **not** open source, and [you cannot modify or redistribute the software](https://choosealicense.com/no-permission/).
+1. Not Open Source - In this case, the cookiecutter will not generate a license. You can add a custom license, or choose
+   to not add a license. If there is no license in a repository, you should assume that the project is **not** open
+   source, and [you cannot modify or redistribute the software](https://choosealicense.com/no-permission/).
 
-For most of your projects, it is likely that the license you choose will not matter a great deal. However, remember that if you ever want to change a license, you may have to get permission of all contributors. So, if you ever start a project that becomes popular or has contributors, be sure to decide your license early!
+For most of your projects, it is likely that the license you choose will not matter a great deal. However, remember that
+if you ever want to change a license, you may have to get permission of all contributors. So, if you ever start a
+project that becomes popular or has contributors, be sure to decide your license early!
 
 > ## Types of Open-Source Licenses
 >
@@ -105,13 +144,20 @@ For most of your projects, it is likely that the license you choose will not mat
 {: .callout}
 
 #### Dependency Source
-This determines some things in set-up for what will be used to install dependencies for testing. This mostly has consequence for the section on Continuous Integration. We have chosen to install dependencies from anaconda with pip fallback. Don't worry too much about this choice for now.
+
+This determines some things in set-up for what will be used to install dependencies for testing. This mostly has
+consequence for the section on Continuous Integration. We have chosen to install dependencies from anaconda with pip
+fallback. Don't worry too much about this choice for now.
 
 #### Support for ReadTheDocs
-This option is to choose whether you would like files associated with the documentation hosting service [ReadTheDocs](https://readthedocs.org/). Choose yes for this workshop.
+
+This option is to choose whether you would like files associated with the documentation hosting
+service [ReadTheDocs](https://readthedocs.org/). Choose yes for this workshop.
 
 ### Reviewing directory contents
-Now we can examine the project layout the CookieCutter has set up for us. Navigate to the newly created `molecool` directory. You should see the following directory structure.
+
+Now we can examine the project layout the CookieCutter has set up for us. Navigate to the newly created `molecool`
+directory. You should see the following directory structure.
 
 ```
 .
@@ -164,9 +210,14 @@ Now we can examine the project layout the CookieCutter has set up for us. Naviga
 ```
 {: .output}
 
-To visualize your project like above you will use "tree". If you do not have tree you can get using `sudo apt-get install tree` on linux, or `brew install tree` on Mac. Note - tree will not show you the helpful labels after '<-' (those were added by us).
+To visualize your project like above you will use "tree". If you do not have tree you can get
+using `sudo apt-get install tree` on linux, or `brew install tree` on Mac. Note - tree will not show you the helpful
+labels after '<-' (those were added by us).
 
-CookieCutter has created a lot of files! This can be thought of as three sections. In the top level of our project we have a folder for tools related to development (`devtools`), documentation (`docs`) and to the package itself (`molecool`). We will first be working in the `molecool` folder to build our package, and adding more things later.
+CookieCutter has created a lot of files! This can be thought of as three sections. In the top level of our project we
+have a folder for tools related to development (`devtools`), documentation (`docs`) and to the package
+itself (`molecool`). We will first be working in the `molecool` folder to build our package, and adding more things
+later.
 
 ~~~
 ...
@@ -183,7 +234,11 @@ CookieCutter has created a lot of files! This can be thought of as three section
 ~~~
 {: .output}
 
-This the only folder we actually have to work with to build our package. The other folders relate to "best practices", which do not technically have to be used in order for your package to be working (but you should do them, and we will talk about them later). You could build this directory structure by hand, but we have just used cookiecutter to set it up for us. This directory will contain all of our python code for our project, as well as sample data (in the `data` folder), and tests (in the `tests` folder.)
+This the only folder we actually have to work with to build our package. The other folders relate to "best practices",
+which do not technically have to be used in order for your package to be working (but you should do them, and we will
+talk about them later). You could build this directory structure by hand, but we have just used cookiecutter to set it
+up for us. This directory will contain all of our python code for our project, as well as sample data (in the `data`
+folder), and tests (in the `tests` folder.)
 
 > ## Packages and modules
 >
@@ -204,7 +259,9 @@ $ cd molecool
 
 ### The `__init__.py` file
 
-The `__init__.py` file is a special file recognized by the Python interpreter which makes a directory into a package. This file can be blank in some cases, however, we will use it to define how the user interacts with the functions in our package.
+The `__init__.py` file is a special file recognized by the Python interpreter which makes a directory into a package.
+This file can be blank in some cases, however, we will use it to define how the user interacts with the functions in our
+package.
 
 ~~~
 """
@@ -224,9 +281,11 @@ del get_versions, versions
 ~~~
 {: .language-python}
 
-The very first section of this file contains a string opened and closed with three quotations. This is a docstring, and has a short description of the file.
+The very first section of this file contains a string opened and closed with three quotations. This is a docstring, and
+has a short description of the file.
 
-The section we will be concerned with is under `# Add imports here`. This is how we define the way functions from modules are used.
+The section we will be concerned with is under `# Add imports here`. This is how we define the way functions from
+modules are used.
 
 In particular, the line
 
@@ -235,24 +294,41 @@ from .functions import *
 ~~~
 {: .language}
 
-goes to the `molecool.py` file, and brings everything that is defined there into the file. When we use our function defined in `functions.py`, that means we will be able to just say `molecool.canvas()` instead of giving the full path `molecool.functions.canvas()`. If that's confusing, don't worry too much for now. We will be returning to this file in a few minutes. For now, just note that it exists and makes our directory into a package.
+goes to the `molecool.py` file, and brings everything that is defined there into the file. When we use our function
+defined in `functions.py`, that means we will be able to just say `molecool.canvas()` instead of giving the full
+path `molecool.functions.canvas()`. If that's confusing, don't worry too much for now. We will be returning to this file
+in a few minutes. For now, just note that it exists and makes our directory into a package.
 
 ### Our first module
-Once inside of the `molecool` folder (`molecool/molecool`), examine the files that are there. View the first module (`functions.py`) in a text editor. We see a few things about this file. The top begins with a description of this module surrounded by three quotations (`"""`). Right now, that is the file name, followed by our short description, then the sentence "Handles the primary functions". We will change this to be more descriptive later. CookieCutter has also created a placeholder function in called `canvas`.  At the start of the `canvas` function, we have a `docstring` (more about this in [documentation]), which describes the function.
+
+Once inside of the `molecool` folder (`molecool/molecool`), examine the files that are there. View the first
+module (`functions.py`) in a text editor. We see a few things about this file. The top begins with a description of this
+module surrounded by three quotations (`"""`). Right now, that is the file name, followed by our short description, then
+the sentence "Handles the primary functions". We will change this to be more descriptive later. CookieCutter has also
+created a placeholder function in called `canvas`. At the start of the `canvas` function, we have a `docstring` (more
+about this in [documentation]), which describes the function.
 
 We will be moving all of the functions we defined in the jupyter notebook into python modules (`.py` files) like these.
 
 ### Python local installs
 
-To develop this package, we will want to something called a developmental install so that we can try out our functions and package as we develop it. 
+To develop this package, we will want to something called a developmental install so that we can try out our functions
+and package as we develop it.
 
 #### Reviewing `setup.py`
-Return to the top directory (`molecool`). One of the files CookieCutter generated is a `setup.py` file. `setup.py` is the build script for [setuptools]. It tells setuptools about your package (such as the name and version) as well as which code files to include. We'll be using this file in the next section.
+
+Return to the top directory (`molecool`). One of the files CookieCutter generated is a `setup.py` file. `setup.py` is
+the build script for [setuptools]. It tells setuptools about your package (such as the name and version) as well as
+which code files to include. We'll be using this file in the next section.
 
 #### Installing your package
-A developer install will allow you to import your package and use it from anywhere on your computer. You will then be able to import your package into scripts in the same way you import `matplotlib` or `numpy`. 
 
-A local install uses the `setup.py` file to install your package by inserting a link to your new project into your Python site-packages folder. To find the location of your site packages folder, you can check your Python path. Open Python (type `python` into your terminal window), and type
+A developer install will allow you to import your package and use it from anywhere on your computer. You will then be
+able to import your package into scripts in the same way you import `matplotlib` or `numpy`.
+
+A local install uses the `setup.py` file to install your package by inserting a link to your new project into your
+Python site-packages folder. To find the location of your site packages folder, you can check your Python path. Open
+Python (type `python` into your terminal window), and type
 
 ~~~
 >>> import sys
@@ -260,7 +336,9 @@ A local install uses the `setup.py` file to install your package by inserting a 
 ~~~
 {: .language-python}
 
-This will give a list of locations python looks for packages when you do an import. One of the locations should end with `python3.7/site_packages`. The site packages folder is where all of your installed packages for a particular environment are located.
+This will give a list of locations python looks for packages when you do an import. One of the locations should end
+with `python3.7/site_packages`. The site packages folder is where all of your installed packages for a particular
+environment are located.
 
 To do a local install, type
 
@@ -269,9 +347,13 @@ $ pip install -e .
 ~~~
 {: .language-bash}
 
-Here, the `-e` indicates that we are installing this project in 'editable' mode (i.e. setuptools "develop mode"), while `.` indicates to install from the local directory (you could also specify a path here). Now, if you examine the contents of your site packages folder, you should see a link to `molecool` (`molecool.egg-link`). The folder has also been added to your path (check `sys.path` again.)
+Here, the `-e` indicates that we are installing this project in 'editable' mode (i.e. setuptools "develop mode"),
+while `.` indicates to install from the local directory (you could also specify a path here). Now, if you examine the
+contents of your site packages folder, you should see a link to `molecool` (`molecool.egg-link`). The folder has also
+been added to your path (check `sys.path` again.)
 
-Now, we can use our package from any directory, similar to how we can use other installed packages like `numpy`. Open Python, and type
+Now, we can use our package from any directory, similar to how we can use other installed packages like `numpy`. Open
+Python, and type
 
 ~~~
 >>> import molecool
@@ -296,7 +378,6 @@ This should work from anywhere on your computer.
 {: .challenge}
 
 Optional dependencies can be installed as well with `pip install -e .[docs,tests]`
-
 
 {% include links.md %}
 [Python's documentation]: https://docs.python.org/3/tutorial/modules.html

--- a/_episodes/02-git.md
+++ b/_episodes/02-git.md
@@ -22,16 +22,13 @@ keypoints:
 
 ## Version Control
 
-Version control keeps a complete history of your work on a given project. It
-facilitates collaboration on projects where everyone can work freely on a part
-of the project without overriding others’ changes. You can move between past
-versions and rollback when needed. Also, you can review the
-history of your project through commit messages that describe changes on the source code
-and see what exactly has been modified in any given commit. You can see who made the
-changes and when it happened.
+Version control keeps a complete history of your work on a given project. It facilitates collaboration on projects where
+everyone can work freely on a part of the project without overriding others’ changes. You can move between past versions
+and rollback when needed. Also, you can review the history of your project through commit messages that describe changes
+on the source code and see what exactly has been modified in any given commit. You can see who made the changes and when
+it happened.
 
-This is greatly beneficial whether you are working independently or within a
-team.
+This is greatly beneficial whether you are working independently or within a team.
 
 > ## git vs. GitHub
 >
@@ -40,7 +37,8 @@ team.
 >
 {: .callout}
 
-MolSSI recommends using the software `git` for version control, and [GitHub] as a hosting service, though there are other options.
+MolSSI recommends using the software `git` for version control, and [GitHub] as a hosting service, though there are
+other options.
 
 Recommended Hosting Service: [GitHub]  
 Other hosting Services: [GitLab], [BitBucket]
@@ -49,20 +47,25 @@ Other hosting Services: [GitLab], [BitBucket]
 
 You should have git installed and configured from the [setup] instructions.
 
-In this section, we are going to  edit files in the Python package that we created earlier, and use `git` to track those changes.
+In this section, we are going to edit files in the Python package that we created earlier, and use `git` to track those
+changes.
 
 First, use a terminal to `cd` into the top directory of the local repository.
 
-In order for git to keep track of your project, or any changes in your project, you must first tell it that you want it to do this. You must manually create check-points in your project if you wish to have points to return to. If you were not using the CookieCutter, you would first have to initialize your project (ie tell git that you were working on a project) using the command `git init`. 
+In order for git to keep track of your project, or any changes in your project, you must first tell it that you want it
+to do this. You must manually create check-points in your project if you wish to have points to return to. If you were
+not using the CookieCutter, you would first have to initialize your project (ie tell git that you were working on a
+project) using the command `git init`.
 
-When we ran the CMS CookieCutter, it actually initialized the use of `git` for us, added our files, and made a commit (how convenient!). We can see this by typing the following into the terminal on Linux or Mac
+When we ran the CMS CookieCutter, it actually initialized the use of `git` for us, added our files, and made a commit (
+how convenient!). We can see this by typing the following into the terminal on Linux or Mac
 
 ~~~
 $ ls -la
 ~~~
 {: .bash}
 
-Here, the `-la` says that we want to list the files in long format (`-l`), and show hidden files (`-a`). 
+Here, the `-la` says that we want to list the files in long format (`-l`), and show hidden files (`-a`).
 
 If you are on Windows and using the Anaconda Prompt:
 
@@ -78,7 +81,8 @@ If you are on Windows and using the Anaconda PowerShell Prompt:
 ~~~
 {: .bash}
 
-You should an output called `.git`, `.git` is a directory where `git` stores the repository data. This is one way that we are in a git repository.
+You should an output called `.git`, `.git` is a directory where `git` stores the repository data. This is one way that
+we are in a git repository.
 
 Next, type
 
@@ -93,15 +97,20 @@ nothing to commit, working tree clean
 ~~~
 {: .output}
 
-This tells us that we are on the `master` branch (more about branching later), and that no files have been changed since the last commit.
+This tells us that we are on the `master` branch (more about branching later), and that no files have been changed since
+the last commit.
 
 Next, type
+
 ~~~
 $ git log
 ~~~
 {: .bash}
 
-You will get an output resembling the following. This is something called your git commit log. Whenever you make a version, or checkpoint, of your project, you will be able to see information about that checkpoint using the `git log` command. The cookie cutter has already made a commit and written a message for you, and that is what we see for this first commit in the log.
+You will get an output resembling the following. This is something called your git commit log. Whenever you make a
+version, or checkpoint, of your project, you will be able to see information about that checkpoint using the `git log`
+command. The cookie cutter has already made a commit and written a message for you, and that is what we see for this
+first commit in the log.
 
 ~~~
 commit 25ab1f1a066f68e433a17454c66531e5a86c112d (HEAD -> master, tag: 0.0.0)
@@ -112,7 +121,8 @@ Date:   Mon Feb 4 10:45:26 2019 -0500
 ~~~
 {: .output}
 
-Each line of this log tells you something important about the commit, or check point that exists for the project. On the first line,
+Each line of this log tells you something important about the commit, or check point that exists for the project. On the
+first line,
 
 ~~~
 commit 25ab1f1a066f68e433a17454c66531e5a86c112d (HEAD -> master, tag: 0.0.0)
@@ -126,24 +136,33 @@ Then, git records the name of the author who made the change.
 Author: Your Name <your_email@something.com>
 ~~~
 
-This should be your information. This way, anyone who downloads this project can see who made each commit. Note that this name and email address matches what you specified when you configured git in the setup, with the name and email address you specified in the cookiecutter having no effect.
+This should be your information. This way, anyone who downloads this project can see who made each commit. Note that
+this name and email address matches what you specified when you configured git in the setup, with the name and email
+address you specified in the cookiecutter having no effect.
 
 ~~~
 Date:   Mon Feb 4 10:45:26 2019 -0500
 ~~~
-Next, it lists the date and time the commit was made. 
+
+Next, it lists the date and time the commit was made.
 
 ~~~
 
     Initial commit after CMS Cookiecutter creation, version 1.0
 ~~~
-Finally, there will be a blank line followed by a commit message. The commit message is a message whoever made the commit chose to write, but should describe the change that took place when the commit was made. This commit message was written by the cookiecutter for you.
 
-When we have more commits (or versions) of our code, `git log` will show a history of these commits, and they will all have the same format discussed above. Right now, we have only one commit - the one created by the CMS CookieCutter.
+Finally, there will be a blank line followed by a commit message. The commit message is a message whoever made the
+commit chose to write, but should describe the change that took place when the commit was made. This commit message was
+written by the cookiecutter for you.
+
+When we have more commits (or versions) of our code, `git log` will show a history of these commits, and they will all
+have the same format discussed above. Right now, we have only one commit - the one created by the CMS CookieCutter.
 
 ## The 3 steps of a commit
 
-Now, we will change some files and use `git` to track those changes. Let's edit our README. Open `README.md` in your text editor of choice. On line 8, you should see the description of the repository we typed when running the CookieCutter. Add the following sentence to your `README` under the initial description and save the file.
+Now, we will change some files and use `git` to track those changes. Let's edit our README. Open `README.md` in your
+text editor of choice. On line 8, you should see the description of the repository we typed when running the
+CookieCutter. Add the following sentence to your `README` under the initial description and save the file.
 
 ~~~
 This repository is currently under development. To do a developmental install, download this repository and type
@@ -155,9 +174,12 @@ in the repository directory.
 
 #### git add, git status, git commit
 
-Making a commit is like making a checkpoint for a particular version of your code. You can easily return to, or revert to that checkpoint.
+Making a commit is like making a checkpoint for a particular version of your code. You can easily return to, or revert
+to that checkpoint.
 
-To create the checkpoint, we first have to make changes to our project. We might modify *many* files at a time in a repository. Thus, the first step in creating a checkpoint (or commit) is to tell `git` which files we want to include in the checkpoint. We do this with a command called `git add`. This adds files to what is called the *staging area*.
+To create the checkpoint, we first have to make changes to our project. We might modify *many* files at a time in a
+repository. Thus, the first step in creating a checkpoint (or commit) is to tell `git` which files we want to include in
+the checkpoint. We do this with a command called `git add`. This adds files to what is called the *staging area*.
 
 Let's look at our output from `git status` again.
 
@@ -173,7 +195,8 @@ no changes added to commit (use "git add" and/or "git commit -a")
 ~~~
 {: .output}
 
-Git even tells us to use `git add` to include what will be committed. Let's follow the instructions and tell `git` that we want to create a checkpoint with the current version of `README.md`
+Git even tells us to use `git add` to include what will be committed. Let's follow the instructions and tell `git` that
+we want to create a checkpoint with the current version of `README.md`
 
 ~~~
 $ git add README.md
@@ -194,19 +217,22 @@ Changes to be committed:
 ~~~
 {: .output}
 
-We are now on the second step of creating a commit. We have `added` our files to the staging area. In our case, we only have one file in the staging area, but we could add more if we needed.
+We are now on the second step of creating a commit. We have `added` our files to the staging area. In our case, we only
+have one file in the staging area, but we could add more if we needed.
 
-To create the checkpoint, or commit, we will now use the `git commit` command. We add a `-m` after the command for "message." Whenever you create a commit, you should write a message about what the commit does.
+To create the checkpoint, or commit, we will now use the `git commit` command. We add a `-m` after the command for "
+message." Whenever you create a commit, you should write a message about what the commit does.
 
 ~~~
 $ git commit -m "update readme to have instructions for developmental install"
 ~~~
 {: .bash}
 
+Now when we look at our log using `git log`, we see the commit we just made along with information about the author and
+the date of the commit.
 
-Now when we look at our log using `git log`, we see the commit we just made along with information about the author and the date of the commit.
-
-Let's continue to edit this readme to include more information. This is a file which will describe what is in this directory. Open `README.md` in your text editor of choice and add the following to the end 
+Let's continue to edit this readme to include more information. This is a file which will describe what is in this
+directory. Open `README.md` in your text editor of choice and add the following to the end
 
 ~~~
 This package requires the following:
@@ -214,7 +240,7 @@ This package requires the following:
   - matplotlib
 ~~~
 
-This file is using a language called [markdown](https://github.com/adam-p/markdown-here/wiki/Markdown-Cheatsheet). 
+This file is using a language called [markdown](https://github.com/adam-p/markdown-here/wiki/Markdown-Cheatsheet).
 
 > ## Check your understanding
 > Create a commit for these changes to your repository.
@@ -260,8 +286,8 @@ $ git log
 
 We now have a log with three commits. This means there are three versions of the repository we are working in.
 
-`git log` lists all commits  made to a repository in reverse chronological order.
-The listing for each commit includes the commit's full identifier,the commit's author, when it was created, and the commit title.
+`git log` lists all commits made to a repository in reverse chronological order. The listing for each commit includes
+the commit's full identifier,the commit's author, when it was created, and the commit title.
 
 We can see differences in files between commits using git diff.
 
@@ -270,9 +296,11 @@ $ git diff HEAD~1
 ~~~
 {: .language-bash}
 
-Here HEAD refers to the point in our commit history (and current branch). When we use `~1`, we are asking git to show us the different of the current point minus one commit.
+Here HEAD refers to the point in our commit history (and current branch). When we use `~1`, we are asking git to show us
+the different of the current point minus one commit.
 
-Lines that have been added are indicated in green with a plus sign next to them ('+'), while lines that have been deleted are indicated in red with a minus sign next to them ('-')
+Lines that have been added are indicated in green with a plus sign next to them ('+'), while lines that have been
+deleted are indicated in red with a minus sign next to them ('-')
 
 ## Viewing out previous versions
 
@@ -299,7 +327,8 @@ d857c74 (HEAD -> master) add information about dependencies to readme
 
 In this log, the commit ID is the first number on the left.
 
-To revert to the version of the repository where we first edited the readme, use the git checkout command with the appropriate commit id.
+To revert to the version of the repository where we first edited the readme, use the git checkout command with the
+appropriate commit id.
 
 ~~~
 $ git checkout 3c0e1c6
@@ -334,7 +363,10 @@ $ git commit -m "Initial commit after CMS Cookiecutter creation, version 1.0"
 
 ## Creating new features - using branches
 
-When you are working on a project to implement new features, it is a good practices to isolate the the changes you are making and work on one particular topic at a time. To do this, you can use something called a **branch** in git. Working on branches allows you to isolate particular changes. If you make sure that your code works before merging to your main or **master** branch, you will ensure that you always have a working version of code on your main branch.
+When you are working on a project to implement new features, it is a good practices to isolate the the changes you are
+making and work on one particular topic at a time. To do this, you can use something called a **branch** in git. Working
+on branches allows you to isolate particular changes. If you make sure that your code works before merging to your main
+or **master** branch, you will ensure that you always have a working version of code on your main branch.
 
 By default, you are typically in the master branch. To create a new branch and move to it, you can use the command
 
@@ -343,7 +375,9 @@ $ git checkout -b new_branch_name
 ~~~
 {: .language-bash}
 
-The command `git checkout` switches branches when followed by a branch name. When you use the `-b` option, git will create the branch and switch to it. For this exercise, we will add a new feature - we are going to add another function to print the [Zen of Python](https://www.python.org/dev/peps/pep-0020/).
+The command `git checkout` switches branches when followed by a branch name. When you use the `-b` option, git will
+create the branch and switch to it. For this exercise, we will add a new feature - we are going to add another function
+to print the [Zen of Python](https://www.python.org/dev/peps/pep-0020/).
 
 First, we'll create a new branch:
 
@@ -352,7 +386,8 @@ $ git checkout -b zen
 ~~~
 {: .language-bash}
 
-Next, add a new function to your `functions.py` module. We are going to add the ability to print "The Zen of Python". You can get the Zen of Python by typing
+Next, add a new function to your `functions.py` module. We are going to add the ability to print "The Zen of Python".
+You can get the Zen of Python by typing
 
 ~~~
 import this
@@ -398,7 +433,8 @@ $ git commit -m "add function to print Zen of Python
 ~~~
 {: .language-bash}
 
-Let's switch back to the master branch to see what it is like. You can see a list of all the branches in your repo by using the command
+Let's switch back to the master branch to see what it is like. You can see a list of all the branches in your repo by
+using the command
 
 ~~~
 $ git branch
@@ -418,7 +454,8 @@ When you look at the `functions.py` module on the master branch, you should not 
 
 You can verify this by using the `git log` command.
 
-Consider that at the same time we have some changes or features we'd like to implement. Let's make a branch to do a documentation update.
+Consider that at the same time we have some changes or features we'd like to implement. Let's make a branch to do a
+documentation update.
 
 Create a new branch
 
@@ -442,9 +479,11 @@ To switch to an existing branch, use
 
 Save and commit this change.
 
-To incorporate these changes in master, you will need to do a `git merge`. When you do a merge, you should be on the branch you would like to merge into. In this case, we will first merge the changes from our `doc_update` branch, then our `zen` branch, so we should be on our `master` branch. Next we will use the `git merge` command.
+To incorporate these changes in master, you will need to do a `git merge`. When you do a merge, you should be on the
+branch you would like to merge into. In this case, we will first merge the changes from our `doc_update` branch, then
+our `zen` branch, so we should be on our `master` branch. Next we will use the `git merge` command.
 
-The syntax for this command is 
+The syntax for this command is
 
 ~~~
 $ git merge branch_name
@@ -475,11 +514,13 @@ This time, you will see a different message, and a text editor will open for a m
 Merge made by the 'recursive' strategy.
 ~~~
 
-This is because `master` and `zen` had development histories which have diverged. Git had to do some work in this case to merge the branches. A merge commit was created. 
+This is because `master` and `zen` had development histories which have diverged. Git had to do some work in this case
+to merge the branches. A merge commit was created.
 
-Merge commits create a branched git history. We can visualize the history of our project by adding `--graph`. There are other workflows you can use to make the commit history more linear, but we will not discuss them in this course.
+Merge commits create a branched git history. We can visualize the history of our project by adding `--graph`. There are
+other workflows you can use to make the commit history more linear, but we will not discuss them in this course.
 
-Once we are done with a feature branch,  we can delete it:
+Once we are done with a feature branch, we can delete it:
 
 ~~~
 $ git branch -d zen
@@ -733,14 +774,15 @@ $ git branch -d zen
 
 
 ## More Tutorials
+
 If you want more `git`, see the following tutorials.
 
 ### Basic git
- - [Software Carpentry Version Control with Git](http://swcarpentry.github.io/git-novice/)
- - [GitHub 15 Minutes to Learn Git](https://try.github.io/)
- - [More on branches and merging](https://git-scm.com/book/en/v2/Git-Branching-Basic-Branching-and-Merging)
- - [Git Commit Best Practices](https://github.com/trein/dev-best-practices/wiki/Git-Commit-Best-Practices)
 
+- [Software Carpentry Version Control with Git](http://swcarpentry.github.io/git-novice/)
+- [GitHub 15 Minutes to Learn Git](https://try.github.io/)
+- [More on branches and merging](https://git-scm.com/book/en/v2/Git-Branching-Basic-Branching-and-Merging)
+- [Git Commit Best Practices](https://github.com/trein/dev-best-practices/wiki/Git-Commit-Best-Practices)
 
 {% include links.md %}
 [GitHub]: https://github.com

--- a/_episodes/03-github.md
+++ b/_episodes/03-github.md
@@ -14,23 +14,33 @@ keypoints:
 ---
 
 ## Putting your repository on GitHub.
-Now, let's put this project on GitHub so that we can share it with others. In your browser, navigate to `github.com`. Log in to you account if you are not already logged in. On the left side of the page, click the green button that says `New` to create a new repository. Give the repository the name `molecool`.
 
-Note for the last question, "Initialize this repository with a README". We will leave this unchecked in our case because we have an existing repository (as described by GitHub, "This will let you immediately clone the repository to your computer. Skip this step if you’re importing an existing repository."). If you were creating the repository on GitHub, you would select this. There are also options for adding a `.gitignore` file or a license. However, since cookiecutter created these for us, we will not add them.
+Now, let's put this project on GitHub so that we can share it with others. In your browser, navigate to `github.com`.
+Log in to you account if you are not already logged in. On the left side of the page, click the green button that
+says `New` to create a new repository. Give the repository the name `molecool`.
+
+Note for the last question, "Initialize this repository with a README". We will leave this unchecked in our case because
+we have an existing repository (as described by GitHub, "This will let you immediately clone the repository to your
+computer. Skip this step if you’re importing an existing repository."). If you were creating the repository on GitHub,
+you would select this. There are also options for adding a `.gitignore` file or a license. However, since cookiecutter
+created these for us, we will not add them.
 
 Click `Create repository`.
 
 Now, GitHub very helpfully gives us directions for how to get our code on GitHub.
 
-Before we follow these directions, let's look at a few things in the repository. When you want to be able to put your code online in a repository, you have to add what git calls `remotes`. Currently, our repository has no remotes. See this by typing
+Before we follow these directions, let's look at a few things in the repository. When you want to be able to put your
+code online in a repository, you have to add what git calls `remotes`. Currently, our repository has no remotes. See
+this by typing
 
 ~~~
 $ git remote -v
 ~~~
 {: .language-bash}
 
+You should see no output. Now, follow the instructions on GitHub under "...or push an existing repository from the
+command line"
 
-You should see no output. Now, follow the instructions on GitHub under "...or push an existing repository from the command line"
 ~~~
 $ git remote add origin https://github.com/YOUR_GITHUB_USERNAME/molecool.git
 dgit branch -M main
@@ -38,24 +48,34 @@ git push -u origin main
 ~~~
 {: .language-bash}
 
-The first command adds a remote named `origin` and sets the URL to our repository. The word `origin` here is simply a word that is a shortcut for the location of our repository. We could have called it anything (like `pickle`, or `banana`, or anything we wanted), but `origin` is used by convention. Now, whenever we say `origin`, git knows that we really mean `https://github.com/YOUR_GITHUB_USERNAME/molecool.git`. 
+The first command adds a remote named `origin` and sets the URL to our repository. The word `origin` here is simply a
+word that is a shortcut for the location of our repository. We could have called it anything (like `pickle`, or `banana`
+, or anything we wanted), but `origin` is used by convention. Now, whenever we say `origin`, git knows that we really
+mean `https://github.com/YOUR_GITHUB_USERNAME/molecool.git`.
 
-The second command changes our primary branch name from `master` to `main`. GitHub recently decided (as of June 2020) to switch the name of your `main` branch from `master` to `main`. However, the `git` software will still name your primary (or first) branch `master`.  After the second command, you will no longer see `master` when using the command `git branch` (instead seeing `main`). 
+The second command changes our primary branch name from `master` to `main`. GitHub recently decided (as of June 2020) to
+switch the name of your `main` branch from `master` to `main`. However, the `git` software will still name your
+primary (or first) branch `master`. After the second command, you will no longer see `master` when using the
+command `git branch` (instead seeing `main`).
 
-The third command copies (or "pushes") everything which we have tracked using git to `origin`. The word `main` means we are pushing the `main` branch. 
+The third command copies (or "pushes") everything which we have tracked using git to `origin`. The word `main` means we
+are pushing the `main` branch.
 
 Now if you refresh the GitHub webpage you should be able to see all of the new files you added to the repository.
 
 ## Working With Multiple Repositories
 
-One of the most potentially frustrating problems in software development is keeping track of all the different copies of the code.
-For example, we might start a project on a local desktop computer, switch to working on a laptop during a conference, and then do performance optimization on a supercomputer.
-In ye olden days, switching between computers was typically accomplished by copying files via a USB drive, or with ssh, or by emailing things to oneself.
-After copying the files, it was very easy to make an important change on one computer, forget about it, and go back to working on the original version of the code on another computer.
-Of course, when collaborating with other people these problems get dramatically worse.
+One of the most potentially frustrating problems in software development is keeping track of all the different copies of
+the code. For example, we might start a project on a local desktop computer, switch to working on a laptop during a
+conference, and then do performance optimization on a supercomputer. In ye olden days, switching between computers was
+typically accomplished by copying files via a USB drive, or with ssh, or by emailing things to oneself. After copying
+the files, it was very easy to make an important change on one computer, forget about it, and go back to working on the
+original version of the code on another computer. Of course, when collaborating with other people these problems get
+dramatically worse.
 
-Git greatly simplifies the process of having multiple copies of a code development project.
-Let's see this in action by making another clone of our GitHub repository. For this next exercise **you must first navigate out of your project folder**.
+Git greatly simplifies the process of having multiple copies of a code development project. Let's see this in action by
+making another clone of our GitHub repository. For this next exercise **you must first navigate out of your project
+folder**.
 
 ~~~
 $ cd ../
@@ -80,8 +100,9 @@ $ cd molecool_friend
 ~~~
 {: .bash}
 
-Check the remote on this repository. Notice that when you clone a repository from GitHub, it automatically has that repository listed as `origin`, and you do not have to add
-the remote the way we did when we did not clone the repository.
+Check the remote on this repository. Notice that when you clone a repository from GitHub, it automatically has that
+repository listed as `origin`, and you do not have to add the remote the way we did when we did not clone the
+repository.
 
 ~~~
 $ git remote -v
@@ -201,8 +222,7 @@ This line doesn't add any value.
 
 ~~~
 
-When working on a project, it is easy to forget exactly what changes we have made to a file.
-To check this, do
+When working on a project, it is easy to forget exactly what changes we have made to a file. To check this, do
 
 ~~~
 $ git diff HEAD testing.txt
@@ -221,8 +241,8 @@ index 166776a..a634bfb 100644
 ~~~
 {: .output}
 
-"HEAD" just means the most recent commit.
-To compare against the commit just before the most recent commit, add "~1" to end of "HEAD":
+"HEAD" just means the most recent commit. To compare against the commit just before the most recent commit, add "~1" to
+end of "HEAD":
 
 ~~~
 $ git diff HEAD~1 testing.txt
@@ -242,7 +262,6 @@ index 0000000..a634bfb
 ~~~
 {: .output}
 
-
 If we want to compare against a specific commit, we can first do "git log" to find the commit's ID, and then do:
 
 ~~~
@@ -250,8 +269,8 @@ $ git diff *commit_id* testing.txt
 ~~~
 {: .bash}
 
-Another problem that we sometimes encounter is wanting to undo all of our changes to a particular file.
-This can be done with
+Another problem that we sometimes encounter is wanting to undo all of our changes to a particular file. This can be done
+with
 
 ~~~
 $ git checkout HEAD testing.txt
@@ -268,17 +287,17 @@ Of course, you could also replace `HEAD` here with `HEAD~1` or a specific commit
 
 ## Ignoring Files
 
-Sometimes while you work on a project, you may end up creating some temporary files.
-For example, if your text editor is Emacs, you may end up with lots of files called `<filename>~`.
-By default, Git tracks all files, including these.
-This tends to be annoying, since it means that any time you do "git status", all of these unimportant files show up.
+Sometimes while you work on a project, you may end up creating some temporary files. For example, if your text editor is
+Emacs, you may end up with lots of files called `<filename>~`. By default, Git tracks all files, including these. This
+tends to be annoying, since it means that any time you do "git status", all of these unimportant files show up.
 
-We are now going to find out how to tell Git to ignore these files, so that it doesn't keep telling us about them ever time we do "git status".
-Even if you aren't working with Emacs, someone else working on your project might, so let's do the courtesy of telling Git not to track these temporary files.
-First, lets ensure that we have a few dummy files. Make empty files called `testing.txt~` and `README.md~` in your repository using your text editor of choice.
+We are now going to find out how to tell Git to ignore these files, so that it doesn't keep telling us about them ever
+time we do "git status". Even if you aren't working with Emacs, someone else working on your project might, so let's do
+the courtesy of telling Git not to track these temporary files. First, lets ensure that we have a few dummy files. Make
+empty files called `testing.txt~` and `README.md~` in your repository using your text editor of choice.
 
-
-While we're at it, also make some other files that aren't important to the project. Make a file called `calculation.out` in `molecool/data` using your text editor of choice.
+While we're at it, also make some other files that aren't important to the project. Make a file called `calculation.out`
+in `molecool/data` using your text editor of choice.
 
 Now check what Git says about these files:
 
@@ -305,7 +324,8 @@ nothing added to commit but untracked files present (use "git add" to track)
 
 Now we will make Git stop telling us about these files.
 
-Earlier, when we looked at the hidden files, you may have noticed a file called `.gitignore`. Cookiecutter created this for us, however, GitHub also has built in `.gitignore` files you can add when creating an empty repository.
+Earlier, when we looked at the hidden files, you may have noticed a file called `.gitignore`. Cookiecutter created this
+for us, however, GitHub also has built in `.gitignore` files you can add when creating an empty repository.
 
 This file is to tell `git` which types of files we would like to ignore (thus the name `.gitignore`)
 
@@ -348,8 +368,8 @@ wheels/
 ...
 ~~~
 
-Git looks at `.gitignore` and ignores any files or directories that match one of the lines.
-Add the following to the end of `.gitignore`:
+Git looks at `.gitignore` and ignores any files or directories that match one of the lines. Add the following to the end
+of `.gitignore`:
 
 ~~~
 # emacs
@@ -391,8 +411,8 @@ $ git push
 ~~~
 {: .bash}
 
-One nice feature of .gitignore is that prevents us from accidentally adding a file that shouldn't be part of the repository.
-For example:
+One nice feature of .gitignore is that prevents us from accidentally adding a file that shouldn't be part of the
+repository. For example:
 
 ~~~
 $ git add data/calculation.in
@@ -470,8 +490,8 @@ hint: See the 'Note about fast-forwards' in 'git push --help' for details.
 ~~~
 {: .output}
 
-The push failed, because the `friend` clone is not up-to-date with the repository on GitHub.
-We can fix this by doing a pull:
+The push failed, because the `friend` clone is not up-to-date with the repository on GitHub. We can fix this by doing a
+pull:
 
 ~~~
 $ git pull
@@ -492,8 +512,7 @@ Automatic merge failed; fix conflicts and then commit the result.
 ~~~
 {: .output}
 
-Unfortunately, the `pull` also failed, due to a `conflict`.
-To see which files have the conflict, we can do:
+Unfortunately, the `pull` also failed, due to a `conflict`. To see which files have the conflict, we can do:
 
 ~~~
 $ git status
@@ -540,10 +559,9 @@ This is the end of testing.txt
 >>>>>>> 12651a37de10d61d9e9eea31c260c15b7ef3b5d4
 ~~~
 
-The conflict is shown within the `<<<<<<<` and `>>>>>>>` bits.
-The part before the `=======` is what we added in the commit in the `devops_friend` clone, while the part after it comes from the original local clone.
-We need to decide what to do about the conflict, tidy it up, and then make a new commit.
-Edit testing.txt so that it reads:
+The conflict is shown within the `<<<<<<<` and `>>>>>>>` bits. The part before the `=======` is what we added in the
+commit in the `devops_friend` clone, while the part after it comes from the original local clone. We need to decide what
+to do about the conflict, tidy it up, and then make a new commit. Edit testing.txt so that it reads:
 
 ~~~
 ***************************************
@@ -566,8 +584,7 @@ $ git push
 ~~~
 {: .bash}
 
-This time everything should work correctly.
-Generally speaking, your procedure when ready to commit should be:
+This time everything should work correctly. Generally speaking, your procedure when ready to commit should be:
 
 ~~~
 $ git commit -m "Commit message"
@@ -579,11 +596,9 @@ $ git push
 
 ## More GitHub Features
 
-Navigate to the GitHub page for your project.
-Click on "testing.txt".
-Here you can see the file and make changes to it.
-Click the edit button, which looks like a small pencil near the upper right of the file text box.
-Add a line that says "I added this line from the GitHub web interface!", so that the file looks like:
+Navigate to the GitHub page for your project. Click on "testing.txt". Here you can see the file and make changes to it.
+Click the edit button, which looks like a small pencil near the upper right of the file text box. Add a line that says "
+I added this line from the GitHub web interface!", so that the file looks like:
 
 ~~~
 ***************************************
@@ -600,31 +615,29 @@ This is the end of testing.txt
 
 ~~~
 
-Scroll to the bottom of the page and write the name "Added a line to testing.txt from the web interface" for this commit.
-Then, click the green "Commit changes" button at the bottom left.
-You should now see that your change appears in the text box.
+Scroll to the bottom of the page and write the name "Added a line to testing.txt from the web interface" for this
+commit. Then, click the green "Commit changes" button at the bottom left. You should now see that your change appears in
+the text box.
 
-Click the "Blame" button to find out who is responsible for each line of code.
-Click the "History" button to see a list of all commits that affected this file.
-You can click on a commit to see exactly what it did.
+Click the "Blame" button to find out who is responsible for each line of code. Click the "History" button to see a list
+of all commits that affected this file. You can click on a commit to see exactly what it did.
 
-Go back to the main project page, and click the "commits" button.
-Here you can see a list of all the commits for this project.
-Clicking them reveals how they changed the code.
+Go back to the main project page, and click the "commits" button. Here you can see a list of all the commits for this
+project. Clicking them reveals how they changed the code.
 
-The "Issues" tab lets you create discussions about bugs, performance limitations, feature requests, or ongoing work that are shared with everyone else who is working on the project.
-Try filling out a quick issue now.
-Then comment and close the issue.
-
+The "Issues" tab lets you create discussions about bugs, performance limitations, feature requests, or ongoing work that
+are shared with everyone else who is working on the project. Try filling out a quick issue now. Then comment and close
+the issue.
 
 ## More Tutorials
+
 If you want more `git`, see the following tutorials.
 
 ### Basic git
- - [Software Carpentry Version Control with Git](http://swcarpentry.github.io/git-novice/)
- - [GitHub 15 Minutes to Learn Git](https://try.github.io/)
- - [Git Commit Best Practices](https://github.com/trein/dev-best-practices/wiki/Git-Commit-Best-Practices)
 
+- [Software Carpentry Version Control with Git](http://swcarpentry.github.io/git-novice/)
+- [GitHub 15 Minutes to Learn Git](https://try.github.io/)
+- [Git Commit Best Practices](https://github.com/trein/dev-best-practices/wiki/Git-Commit-Best-Practices)
 
 {% include links.md %}
 [GitHub]: https://github.com

--- a/_episodes/04-function-style.md
+++ b/_episodes/04-function-style.md
@@ -20,7 +20,9 @@ keypoints:
 {: .prereq}
 
 # Editing function to our package
-Let's look at one of the functions in our package. Open your `molecool/functions.py` module in a text editor. The function `open_pdb` reads coordinates and atom symbols from a pdb file.
+
+Let's look at one of the functions in our package. Open your `molecool/functions.py` module in a text editor. The
+function `open_pdb` reads coordinates and atom symbols from a pdb file.
 
 ~~~
 def open_pdb(f_loc):
@@ -38,9 +40,16 @@ def open_pdb(f_loc):
 ~~~
 {: .language-python}
 
-If we want to test our function, we require a pdb file. The workshop materials downloaded during the setup include a set of pdb examples. These are found in `molssi_beter_practices/starting_material/data/pdb/`. We want to store these files in our molecool directory. Luckily, cookicutter created a folder designed specifically for that purpose. The folder is in `molecool/data/`. This folder can contain any data useful for testing of the basic functionality of our code. Be mindful given that this folder is also downloaded when installing our package, so do not include data whose size is significant. 
+If we want to test our function, we require a pdb file. The workshop materials downloaded during the setup include a set
+of pdb examples. These are found in `molssi_beter_practices/starting_material/data/pdb/`. We want to store these files
+in our molecool directory. Luckily, cookicutter created a folder designed specifically for that purpose. The folder is
+in `molecool/data/`. This folder can contain any data useful for testing of the basic functionality of our code. Be
+mindful given that this folder is also downloaded when installing our package, so do not include data whose size is
+significant.
 
-Go ahead and copy the pdb files in a new folder `pdb` inside the data folder. With the files in our molecool folder, we can access the function when we execute it in the interactive Python interpreter. Test this by opening the interactive Python interpreter and typing the following
+Go ahead and copy the pdb files in a new folder `pdb` inside the data folder. With the files in our molecool folder, we
+can access the function when we execute it in the interactive Python interpreter. Test this by opening the interactive
+Python interpreter and typing the following
 
 ~~~
 >>> import os
@@ -56,8 +65,9 @@ Go ahead and copy the pdb files in a new folder `pdb` inside the data folder. Wi
 ~~~
 {: .output}
 
-You should get a list of atomic symbols of the water molecule from executing this code.
-You can also see the atomic coordinates by executing:
+You should get a list of atomic symbols of the water molecule from executing this code. You can also see the atomic
+coordinates by executing:
+
 ~~~
 >>> coords
 ~~~
@@ -72,11 +82,16 @@ array([[ 9.626,  6.787, 12.673],
 ~~~
 {: .output}
 
-Hooray! It seems like this function works! This should come as no surprise since we are the authors of the function and we know its internal structure. This is not necessarily true for someone editing our code and specially not true for someone just using our code. There are instances where even though the code is executed correctly, i.e., there where no syntax errors, an unwanted expected behavior occurs. In these cases, our code should be able to stop itself to prevent a malfunction. 
+Hooray! It seems like this function works! This should come as no surprise since we are the authors of the function and
+we know its internal structure. This is not necessarily true for someone editing our code and specially not true for
+someone just using our code. There are instances where even though the code is executed correctly, i.e., there where no
+syntax errors, an unwanted expected behavior occurs. In these cases, our code should be able to stop itself to prevent a
+malfunction.
 
-## Raising Errors 
+## Raising Errors
 
-Take for example the division by zero. If we try to calculate 
+Take for example the division by zero. If we try to calculate
+
 ~~~
 >>> 1/0
 ~~~
@@ -89,7 +104,10 @@ ZeroDivisionError: division by zero
 ~~~
 {: .output}
 
-In this example, the code was smart enough to identify the division by zero and halted. This type of feedback is much more helpful than just throwing an ugly `NaN`. This is called an exception error. There are several built-in exception such as the "ZeroDivisionError". You can choose to raise errors yourself when you think a function should fail (instead of the function not failing, or running until it hit a failure.)
+In this example, the code was smart enough to identify the division by zero and halted. This type of feedback is much
+more helpful than just throwing an ugly `NaN`. This is called an exception error. There are several built-in exception
+such as the "ZeroDivisionError". You can choose to raise errors yourself when you think a function should fail (instead
+of the function not failing, or running until it hit a failure.)
 
 Consider our function `write_xyz`
 
@@ -109,7 +127,11 @@ def write_xyz(file_location, symbols, coordinates):
 ~~~
 {: .language-python}
 
-When examining this function, you may see a few opportunities for failure. For example, a user could supply `symbols` and `coordinates` with different lengths. If the `coordinates` argument is the longer one, we will not see an error raised. The function will simply ignore the last coordinate. If `symbols` is the longer argument, we will not have enough `coordinates` and an error will occur. Neither of these is our intention, and one of them would complete without us knowing (some errors are silent)!
+When examining this function, you may see a few opportunities for failure. For example, a user could supply `symbols`
+and `coordinates` with different lengths. If the `coordinates` argument is the longer one, we will not see an error
+raised. The function will simply ignore the last coordinate. If `symbols` is the longer argument, we will not have
+enough `coordinates` and an error will occur. Neither of these is our intention, and one of them would complete without
+us knowing (some errors are silent)!
 
 Let's try this out. In a python interpreter, try the following:
 
@@ -124,7 +146,9 @@ Let's try this out. In a python interpreter, try the following:
 
 You will see that no error occurs. If we open the written XYZ file, the last coordinate point has been discarded.
 
-We probably intend for these variables to have the same number of elements. When they don't, there's no way to tell what the user wanted, or if they have accidentally passed us incorrect data. We should check the length of theses and raise an appropriate exception to halt the program if necessary. 
+We probably intend for these variables to have the same number of elements. When they don't, there's no way to tell what
+the user wanted, or if they have accidentally passed us incorrect data. We should check the length of theses and raise
+an appropriate exception to halt the program if necessary.
 
 ~~~
 def write_xyz(file_location, symbols, coordinates):
@@ -145,7 +169,8 @@ def write_xyz(file_location, symbols, coordinates):
 ~~~
 {: .language-python}
 
-As you can see, custom error messages can be quite descriptive of the problem. Let's try this out with some fake data. Using the same example as before:
+As you can see, custom error messages can be quite descriptive of the problem. Let's try this out with some fake data.
+Using the same example as before:
 
 ~~~
 >>> import molecool
@@ -161,17 +186,25 @@ ValueError: write_xyz : the number of symbols (2) and number of coordinates (3) 
 ~~~
 {: .output}
 
-The already built-in exceptions include errors that are common while programming. For example, our function requires explicit use of numpy arrays. Nevertheless, a user may be tempted to use a list of length 3 to describe the position of two atoms. We know that it is not possible to perform arithmetic between full lists. In this case we might use the exception type `TypeError`.
+The already built-in exceptions include errors that are common while programming. For example, our function requires
+explicit use of numpy arrays. Nevertheless, a user may be tempted to use a list of length 3 to describe the position of
+two atoms. We know that it is not possible to perform arithmetic between full lists. In this case we might use the
+exception type `TypeError`.
 
-Other types of common exceptions include variables not being defined (`NameError`) or asserting that two numbers are the same (assert). The latter will be particularly useful when we want to automatize testing within our package. 
+Other types of common exceptions include variables not being defined (`NameError`) or asserting that two numbers are the
+same (assert). The latter will be particularly useful when we want to automatize testing within our package.
 
 ## Coding Style
 
-Our functions are now smarter and will better guide users while using them. However, our function still might be hard to read and understand for others so we might want to consider styling it properly.
+Our functions are now smarter and will better guide users while using them. However, our function still might be hard to
+read and understand for others so we might want to consider styling it properly.
 
-As a developer, you spend a lot of time thinking about writing your code. However, code is read much more often than it is written. Following a style guide will help others (and perhaps you in the future!) to read your code.
+As a developer, you spend a lot of time thinking about writing your code. However, code is read much more often than it
+is written. Following a style guide will help others (and perhaps you in the future!) to read your code.
 
-For Python, the common convention for code style is called [PEP8]. PEP8 is a document that gives guidelines for best practices in Python coding style. PEP8 is a recommendation, not rule. However, you should follow this convention when possible.
+For Python, the common convention for code style is called [PEP8]. PEP8 is a document that gives guidelines for best
+practices in Python coding style. PEP8 is a recommendation, not rule. However, you should follow this convention when
+possible.
 
 > ## Python PEP
 >
@@ -180,18 +213,21 @@ For Python, the common convention for code style is called [PEP8]. PEP8 is a doc
 > You can read more about PEPs in [Python's documentation](https://www.python.org/dev/peps/pep-0001/). PEP1 outlines what a PEP is and how they work.
 {: .callout}
 
-PEP8 tells us several things about styling that will make our code easier to read. Let's consider some of these and how they might change our function.
+PEP8 tells us several things about styling that will make our code easier to read. Let's consider some of these and how
+they might change our function.
 
 ## Variable names
+
 PEP8 recommends that
 
 > Never use the characters 'l' (lowercase letter el), 'O' (uppercase letter oh), or 'I' (uppercase letter eye) as single character variable names.
- 
 > Function names should be lowercase, with words separated by underscores as necessary to improve readability.
 
-Though not specifically reference in PEP8, we also recommend making all variable names descriptive so that someone reading your code can easily understand what the variable is. 
+Though not specifically reference in PEP8, we also recommend making all variable names descriptive so that someone
+reading your code can easily understand what the variable is.
 
-Consider a few variable we have defined in our function (`c`, `sym`, `c2`, `l`). Is it clear what these are or mean? We can change them to be more descriptive and readable.
+Consider a few variable we have defined in our function (`c`, `sym`, `c2`, `l`). Is it clear what these are or mean? We
+can change them to be more descriptive and readable.
 
 ~~~
 def open_pdb(file_location):
@@ -217,7 +253,7 @@ For this rewrite of the function, we have made the following changes in variable
 - `l` ---> `line`
 - `c2` ---> `atom_coords`
 
-These variable names follow PEP8 convention and are much more descriptive and readable. 
+These variable names follow PEP8 convention and are much more descriptive and readable.
 
 ## Indentation
 
@@ -227,7 +263,8 @@ PEP8 indicates that indentation should be 4 spaces per indentation level. Our co
 
 > Always surround these binary operators with a single space on either side: assignment (=), augmented assignment (+=, -= etc.), comparisons (==, <, >, !=, <>, <=, >=, in, not in, is, is not), Booleans (and, or, not).
 
-This means that every time we have an expression assigning a variable, it should be `variable = value` instead of `variable=value`.
+This means that every time we have an expression assigning a variable, it should be `variable = value` instead
+of `variable=value`.
 
 You can also use whitespace to separate ideas within a function or code.
 
@@ -288,7 +325,8 @@ $ git push origin main
 > {: .solution}
 {: .challenge}
 
-Now we've successfully styled function according to PEP8! However, if we compare what we've written above to the sample function, `canvas`, we notice that ours is a little different.
+Now we've successfully styled function according to PEP8! However, if we compare what we've written above to the sample
+function, `canvas`, we notice that ours is a little different.
 
 Keeping your previous Python interpreter open, type the following:
 
@@ -299,7 +337,8 @@ help(mc.canvas)
 
 **Note: Do not use `help(mc.canvas())`, this will actually execute your code (not what we want).**
 
-The code above calls Python's built-in function, `help`. For our canvas function, it displays the multi-line comment (called a `docstring`), that is written beneath the function definition.
+The code above calls Python's built-in function, `help`. For our canvas function, it displays the multi-line comment (
+called a `docstring`), that is written beneath the function definition.
 
 ~~~
 Help on function canvas in module molecool.functions:
@@ -323,7 +362,9 @@ canvas(with_attribution=True)
 
 If we try the same thing on our `calculate_distance` function, we don't get a helpful message.
 
-We will want to write a docstring for our new `calculate_distance` function. This way, it will be clear to new developers who use our code what the function does, and be accessible to any users using the function interactively. Returning, to the `functions.py` module file, edit your `calculate_distance` function to look like the following:
+We will want to write a docstring for our new `calculate_distance` function. This way, it will be clear to new
+developers who use our code what the function does, and be accessible to any users using the function interactively.
+Returning, to the `functions.py` module file, edit your `calculate_distance` function to look like the following:
 
 ~~~
 def calculate_distance(rA, rB):
@@ -353,9 +394,11 @@ def calculate_distance(rA, rB):
 ~~~
 {: .language-python}
 
-
 ## Docstrings
-We've now added a multi-line comment (called a `docstring`, short for "documentation string"), to the beginning of our function. Docstrings **are the first statement after a function or module definition** and are opened and closed with three quotes.
+
+We've now added a multi-line comment (called a `docstring`, short for "documentation string"), to the beginning of our
+function. Docstrings **are the first statement after a function or module definition** and are opened and closed with
+three quotes.
 
 The docstring should explain what the function or module does (and not how it is done).
 
@@ -367,12 +410,18 @@ The docstring should explain what the function or module does (and not how it is
 {: .callout}
 
 ### Sections of a Docstring
-There are many ways you could format this docstring (different styles/conventions). We recommend using [numpy style docstrings], and this is what the example above and `calculate_distance` function are written in.
 
-Each docstring has a number of sections which are separated by headings. Headings should be underlined with hyphens (`-----`). There are many options for sections, we will only cover the most relevant here. If you would like to see a full list, check out the documentation for [numpy style docstrings].
+There are many ways you could format this docstring (different styles/conventions). We recommend
+using [numpy style docstrings], and this is what the example above and `calculate_distance` function are written in.
+
+Each docstring has a number of sections which are separated by headings. Headings should be underlined with
+hyphens (`-----`). There are many options for sections, we will only cover the most relevant here. If you would like to
+see a full list, check out the documentation for [numpy style docstrings].
 
 #### 1. Short summary
-A one-line summary that does not use the variable name or the function name. In our `calculate_distance` function, this corresponds to the following.
+
+A one-line summary that does not use the variable name or the function name. In our `calculate_distance` function, this
+corresponds to the following.
 
 ~~~
 """
@@ -382,11 +431,14 @@ Calculate the distance between two points.
 {: .language-python}
 
 #### 2. Extended summary
-A few sentences giving a detailed description of the function or module. This section should be used to clarify *functionality*, not to discuss implementation.
+
+A few sentences giving a detailed description of the function or module. This section should be used to clarify *
+functionality*, not to discuss implementation.
 
 We do not have an extended summary in our `calculate_distance` function, since it is relatively straightforward.
 
 #### 3. Parameters
+
 This section contains a description of the function arguments - keywords and expected types.
 
 The parameters for our `calculate_distance` function is shown below:
@@ -401,10 +453,16 @@ rA, rB : np.ndarray
 ~~~
 {: .language-python}
 
-Here, you can see that the parameter section begins with the section title ("Parameters"), followed by a line of hypens ("----"). On the next line, we have the argument names (`rA, rB`), then a colon followed by the input type of the argument. This line says that the arguments `rA` and `rB` should be of type `np.ndarray`. The next line gives a more detailed description of the variable. When the input parameters are of different type or they aren't related to each other they should be written on a new line.
+Here, you can see that the parameter section begins with the section title ("Parameters"), followed by a line of
+hypens ("----"). On the next line, we have the argument names (`rA, rB`), then a colon followed by the input type of the
+argument. This line says that the arguments `rA` and `rB` should be of type `np.ndarray`. The next line gives a more
+detailed description of the variable. When the input parameters are of different type or they aren't related to each
+other they should be written on a new line.
 
 #### 4. Returns
-This section is very similar to the `Parameters` section above. In contrast to the `Parameters` section, each returned value does not have to be named, but the type of the return value is required.
+
+This section is very similar to the `Parameters` section above. In contrast to the `Parameters` section, each returned
+value does not have to be named, but the type of the return value is required.
 
 For our `calculate_distance` function, our `Returns` section looks like the following.
 
@@ -419,7 +477,9 @@ distance : float
 {: .language-python}
 
 #### 5. Examples
-This is an optional section to show examples of functionality. This section is meant to illustrate usage. Though this section is optional, its use is strongly encouraged.
+
+This is an optional section to show examples of functionality. This section is meant to illustrate usage. Though this
+section is optional, its use is strongly encouraged.
 
 Consider the example we have in our docstring
 
@@ -435,9 +495,14 @@ Examples
 ~~~
 {: .language-python}
 
-It is important that your Examples in docstrings be working Python. We will see in the `testing` lesson how we can run automatic tests on our docstrings, and in the `documentation` lesson, we will see how we can display examples in documentation to our users. 
+It is important that your Examples in docstrings be working Python. We will see in the `testing` lesson how we can run
+automatic tests on our docstrings, and in the `documentation` lesson, we will see how we can display examples in
+documentation to our users.
 
-We have three lines of code for our example. In examples, lines of code begin with `>>>`. The first two lines define numpy arrays that are used in our `calculate_distance` function. Note that `r1` and `r2` must be numpy arrays (as indicated by our `Parameters` section), or our Example will not give valid Python code (our function would error if we ran it). On the last line, you give the output (with no `>>>` in front.)
+We have three lines of code for our example. In examples, lines of code begin with `>>>`. The first two lines define
+numpy arrays that are used in our `calculate_distance` function. Note that `r1` and `r2` must be numpy arrays (as
+indicated by our `Parameters` section), or our Example will not give valid Python code (our function would error if we
+ran it). On the last line, you give the output (with no `>>>` in front.)
 
 Now that we've written a function in our project, we should commit our changes and push to GitHub.
 
@@ -512,11 +577,17 @@ $ git push origin main
 
 ## More on Coding Style
 
-If you look at PEP8, you will see that it is quite long. While you should definitely read it if you spend a lot of time programming in Python, there are luckily tools which will help us make sure our code is following PEP8 convention or other styling guidelines. There are autoformattign tools such as`yapf` and `Black` and static code "linters" such as `pylint` or `flake8`.
+If you look at PEP8, you will see that it is quite long. While you should definitely read it if you spend a lot of time
+programming in Python, there are luckily tools which will help us make sure our code is following PEP8 convention or
+other styling guidelines. There are autoformattign tools such as`yapf` and `Black` and static code "linters" such
+as `pylint` or `flake8`.
 
-Automatic code formatters will parse over your python files and format them according to standards defined by that code formatter. It is usually a good idea to use a formatter (of your choice) when working on a python project. In particular, [Black](https://github.com/psf/black) has gained popularity lately. 
+Automatic code formatters will parse over your python files and format them according to standards defined by that code
+formatter. It is usually a good idea to use a formatter (of your choice) when working on a python project. In
+particular, [Black](https://github.com/psf/black) has gained popularity lately.
 
-We will use [Black](https://github.com/psf/black) in this workshop. Black is an autoformatter which is almost entirely non customizable, ensuring all of your files will be uniform. 
+We will use [Black](https://github.com/psf/black) in this workshop. Black is an autoformatter which is almost entirely
+non customizable, ensuring all of your files will be uniform.
 
 Install black using pip. In your terminal, type
 
@@ -532,7 +603,12 @@ $ black molecool/functions.py
 ~~~
 {: .language-bash}
 
-You can see the changes to the `write_xyz` function, for example. You'll notice that Black also has some rules which are in addition to PEP8 formatting. For example, strings are all normalized to use double quotes. Note that `black` does not always follow PEP8. For example, PEP8 recommends that line lengths be no more than 79 characters. This is a convention which is most often not followed. Black defaults to 88 characters per line instead. When you are working on a project, the exact style you use may vary - however, it is important to define a style. This will make your code much cleaner and easier to read.
+You can see the changes to the `write_xyz` function, for example. You'll notice that Black also has some rules which are
+in addition to PEP8 formatting. For example, strings are all normalized to use double quotes. Note that `black` does not
+always follow PEP8. For example, PEP8 recommends that line lengths be no more than 79 characters. This is a convention
+which is most often not followed. Black defaults to 88 characters per line instead. When you are working on a project,
+the exact style you use may vary - however, it is important to define a style. This will make your code much cleaner and
+easier to read.
 
 Now that we've changed and formatted some functions in our project, we should commit our changes and push to GitHub.
 
@@ -543,7 +619,11 @@ $ git push origin master
 ~~~
 {: .bash}
 
-There are other tools, such as [pylint](https://www.pylint.org/) or [flake8](https://flake8.pycqa.org/en/latest/) which are not automatic formatters, but will check your code for adherence to the PEP8 standard. Pylint, for example, will find your variables which are not `snake_case`, functions which do not have `docstrings`, simple stylistic changes, unused variables, etc. Flake8 is a little less strict in general. We will try `flake8` out here.  If you would like to try `flake8`, first install it
+There are other tools, such as [pylint](https://www.pylint.org/) or [flake8](https://flake8.pycqa.org/en/latest/) which
+are not automatic formatters, but will check your code for adherence to the PEP8 standard. Pylint, for example, will
+find your variables which are not `snake_case`, functions which do not have `docstrings`, simple stylistic changes,
+unused variables, etc. Flake8 is a little less strict in general. We will try `flake8` out here. If you would like to
+try `flake8`, first install it
 
 ~~~
 $ pip install flake8
@@ -557,14 +637,15 @@ $ flake8 molecool/functions.py
 ~~~
 {: .language-bash}
 
-To see any errors still left in the module. Let's examine one of these 
+To see any errors still left in the module. Let's examine one of these
 
 ~~~
 molecool/functions.py:1:1: F401 'os' imported but unused
 ~~~
 {: .language-output}
 
-This tells us it is looking at the line `molecool/functions.py` on line `1` (your line number may vary). `F401` is an error code which you can look up. Here, we are importing `os`, but never using it. We should remove this from our file.
+This tells us it is looking at the line `molecool/functions.py` on line `1` (your line number may vary). `F401` is an
+error code which you can look up. Here, we are importing `os`, but never using it. We should remove this from our file.
 
 You will also see a second "unused import" error:
 
@@ -573,14 +654,16 @@ molecool/functions.py:5:1: F401 'mpl_toolkits.mplot3d.Axes3D' imported but unuse
 ~~~
 {: .language-python}
 
-Althought it appears this isn't used, this import is actually necessary for our 3D plot. We can tell `flake8` to ignore this problem by adding a special comment:
+Althought it appears this isn't used, this import is actually necessary for our 3D plot. We can tell `flake8` to ignore
+this problem by adding a special comment:
 
 ~~~
 from mpl_toolkits.mplot3d import Axes3D  # noqa: F401
 ~~~
 {: .language-python}
 
-You can run `flake8` again to see that the import error is no longer reported. However, if your comment is not correctly formatted, you will have an additional error from that.
+You can run `flake8` again to see that the import error is no longer reported. However, if your comment is not correctly
+formatted, you will have an additional error from that.
 
 
 [Exceptions]: https://realpython.com/python-exceptions/#the-try-and-except-block-handling-exceptions

--- a/_episodes/05-package-structure.md
+++ b/_episodes/05-package-structure.md
@@ -13,12 +13,21 @@ keypoints:
 - "You can use the __init__.py file to define what packages are imported with your package, and how the user interacts with it."
 ---
 
-As new features are implemented in codes, it is natural for new functions and objects to be added. In many projects, this often leads to a large number of functionalities defined within a single module. For small, single developer codes, this is not a major issue, but it can still make it difficult to work with. With large or multi-developer codes, this can slow development progress to a crawl as it is difficult to both understand and work with the code.
+As new features are implemented in codes, it is natural for new functions and objects to be added. In many projects,
+this often leads to a large number of functionalities defined within a single module. For small, single developer codes,
+this is not a major issue, but it can still make it difficult to work with. With large or multi-developer codes, this
+can slow development progress to a crawl as it is difficult to both understand and work with the code.
 
-In this lesson, we will simulate a developing code by starting with a single python module containing all the methods we have developed, and converting it into a well structured package.
+In this lesson, we will simulate a developing code by starting with a single python module containing all the methods we
+have developed, and converting it into a well structured package.
 
 ## Package Structure
-Lets start by reviewing the package structure provided to us by the [CMS CookieCutter]. We have a directory containing our project with a number of additional features. Under our package directory, `molecool`, we can see our current python module `functions.py`. For a more detailed explanation of the rest of the package structure, please review the [package setup] section of the lessons.
+
+Lets start by reviewing the package structure provided to us by the [CMS CookieCutter]. We have a directory containing
+our project with a number of additional features. Under our package directory, `molecool`, we can see our current python
+module `functions.py`. For a more detailed explanation of the rest of the package structure, please review
+the [package setup] section of the lessons.
+
 ```
 .
 ├── CODE_OF_CONDUCT.md              <- Code of Conduct for developers and users
@@ -70,7 +79,10 @@ Lets start by reviewing the package structure provided to us by the [CMS CookieC
 ```
 {: .output}
 
-The easiest way to start is to see what we currently have and try and decide what is related to one another. Looking through the `functions.py` file, we see a number of different functions, and for the sake of simplicity we abbreviate and rearrange them here:
+The easiest way to start is to see what we currently have and try and decide what is related to one another. Looking
+through the `functions.py` file, we see a number of different functions, and for the sake of simplicity we abbreviate
+and rearrange them here:
+
 ```
 atomic_weights = {
     'H': 1.00784,
@@ -117,12 +129,21 @@ def calculate_center_of_mass(symbols, coordinates):
 ```
 {: .language-python}
 
-Right at the start we can see two dictionaries of atom data. Clearly these are related and should probably be grouped together. Looking at the functions, we see two functions that handle opening files, `open_pdb` and `open_xyz`, and a function that writes a file, `write_xyz`. It may make sense to group these three together in a module based on input and output.
+Right at the start we can see two dictionaries of atom data. Clearly these are related and should probably be grouped
+together. Looking at the functions, we see two functions that handle opening files, `open_pdb` and `open_xyz`, and a
+function that writes a file, `write_xyz`. It may make sense to group these three together in a module based on input and
+output.
 
 Lets start making new modules to place our related functions into.
 
 ### Atom Data
-We will take the `atomic_weights` and `atom_colors` dictionaries and move them into a separate module called `atom_data.py`. This is enclosing the constant data that our system is using in a single place. This allows all of the new modules we create to access the data from a single location, avoiding the need to copy the dictionaries to each module that needs them. If we have any other data, related to atoms, used by many of our functions, adding them to this module would be a good idea.
+
+We will take the `atomic_weights` and `atom_colors` dictionaries and move them into a separate module
+called `atom_data.py`. This is enclosing the constant data that our system is using in a single place. This allows all
+of the new modules we create to access the data from a single location, avoiding the need to copy the dictionaries to
+each module that needs them. If we have any other data, related to atoms, used by many of our functions, adding them to
+this module would be a good idea.
+
 ```
 """
 Data used for the rest of the package.
@@ -165,7 +186,11 @@ atom_colors = {
 {: .challenge}
 
 ### Measure
-Our `functions.py` file contains two functions that handle taking measurements, `calculate_distance` and `calculate_angle`. Simliar to `atom_data`, we will simply place these in a module within the main package. Since both functions are taking measurements, we will call it `measure.py`.
+
+Our `functions.py` file contains two functions that handle taking measurements, `calculate_distance`
+and `calculate_angle`. Simliar to `atom_data`, we will simply place these in a module within the main package. Since
+both functions are taking measurements, we will call it `measure.py`.
+
 ```
 """
 This module is for functions which perform measurements.
@@ -188,7 +213,10 @@ def calculate_angle(rA, rB, rC, degrees=False):
 {: .language-python}
 
 ### Visualize
-Similarly, we have two functions that handle visulaization of molecules. We will place them into a module called `visualize.py`.
+
+Similarly, we have two functions that handle visulaization of molecules. We will place them into a module
+called `visualize.py`.
+
 ```
 """
 Functions for visualization of molecules
@@ -249,9 +277,12 @@ def bond_histogram(bond_list, save_location=None, dpi=300, graph_min=0, graph_ma
 ```
 {: .language-python}
 
-
 ### Molecule
-Our last function is `build_bond_list` which is not particularly related to any of our other functions (docstring added). The name `functions.py` does not really give a lot of information about what is available in the module. We can rename the module to something more fitting, say `molecule.py`.
+
+Our last function is `build_bond_list` which is not particularly related to any of our other functions (docstring added)
+. The name `functions.py` does not really give a lot of information about what is available in the module. We can rename
+the module to something more fitting, say `molecule.py`.
+
 ```
 def build_bond_list(coordinates, max_bond=1.5, min_bond=0):
     """
@@ -288,12 +319,15 @@ def build_bond_list(coordinates, max_bond=1.5, min_bond=0):
 ```
 {: .language-python}
 
-
 ### I/O Package
-When looking at the three I/O functions, it may be easy to jump ahead and create an I/O module, as mentioned previously, however, what we really have is two distinct groups of functions that are related. More specifically, we have two functions that handle the input and output of a `.xyz` file and another function that handles the input of a `.pdb`. Each group is handling input and output, but are still somewhat unrelated because of their file type. Instead of making a single module, we are going to create a subpackage to handle i/o and place a module for each group within it.
+
+When looking at the three I/O functions, it may be easy to jump ahead and create an I/O module, as mentioned previously,
+however, what we really have is two distinct groups of functions that are related. More specifically, we have two
+functions that handle the input and output of a `.xyz` file and another function that handles the input of a `.pdb`.
+Each group is handling input and output, but are still somewhat unrelated because of their file type. Instead of making
+a single module, we are going to create a subpackage to handle i/o and place a module for each group within it.
 
 Create a new directory called io within the package and create two new files `pdb.py` and `xyz.py`:
-
 
 `pdb.py`
 ```
@@ -346,10 +380,19 @@ def write_xyz(file_location, symbols, coordinates):
                                               coordinates[i,0], coordinates[i,1], coordinates[i,2]))
 ```
 {: .language-python}
-Now any module that needs to handle input and output can import the needed module from the `io` package. Since these are currently small modules, it would not be a big deal to import all of them, but consider a large I/O suite contianing a large number of file types and functionalities, it will quickly create inefficiencies to leave them in one module.
+
+Now any module that needs to handle input and output can import the needed module from the `io`
+package. Since these are currently small modules, it would not be a big deal to import all of them, but consider a large
+I/O suite contianing a large number of file types and functionalities, it will quickly create inefficiencies to leave
+them in one module.
 
 ## Fixing Imports
-When we first copied the functions from the Jupyter Notebook into `functions.py`, we were able to import `molecool` package and access the functions within `functions.py`. After we extracted the functions from that file, we won't be able to import those functions in the same way. In fact we won't be able to access them at all. Every time we restructure our code or create new folders we have to be careful and modify the init accordingly. Let us then add the new functions into the `__init__`
+
+When we first copied the functions from the Jupyter Notebook into `functions.py`, we were able to import `molecool`
+package and access the functions within `functions.py`. After we extracted the functions from that file, we won't be
+able to import those functions in the same way. In fact we won't be able to access them at all. Every time we
+restructure our code or create new folders we have to be careful and modify the init accordingly. Let us then add the
+new functions into the `__init__`
 
 ~~~
 # Add imports here
@@ -368,17 +411,24 @@ In this way, we should be able to call each of the functions after importing our
 ~~~
 {: .language-python}
 
-Even with the imports fixed, if you try and run some of these functions, you may find yourself with an `ImportError`. This is because the functions can only see the code that has been "loaded" into the module. Each set of functions now exists as standalones within their module. 
+Even with the imports fixed, if you try and run some of these functions, you may find yourself with an `ImportError`.
+This is because the functions can only see the code that has been "loaded" into the module. Each set of functions now
+exists as standalones within their module.
 
-If we look at our original `functions.py` module, we will see that we had a number of import statements at the top of the file:
+If we look at our original `functions.py` module, we will see that we had a number of import statements at the top of
+the file:
+
 ```
 import os
 import numpy as np
 import matplotlib.pyplot as plt
 ```
 {: .language-python}
-These are modules that some of the functions need to run. Now that we have moved the functions into separate modules, we need to add in the import statements into each file where they are needed. Lets start by looking at `measure.py`. Looking through the functions, we can see that each of them has a reference to `np`, which is what 
-we imported `numpy` as in `functions.py`. 
+
+These are modules that some of the functions need to run. Now that we have moved the functions into
+separate modules, we need to add in the import statements into each file where they are needed. Lets start by looking
+at `measure.py`. Looking through the functions, we can see that each of them has a reference to `np`, which is what we
+imported `numpy` as in `functions.py`.
 
 Besides visual inspection, you could have also seen these missing imports by using `flake8` on the modules.
 
@@ -390,6 +440,7 @@ $ flake8 measure.py
 You will see a message which says "undefined name np"
 
 In order to make these functions work again, we need to add the import statement
+
 ```
 import numpy as np
 ```
@@ -397,7 +448,11 @@ import numpy as np
 
 to the top of our file.
 
-As a second example, let us look at the `visualize.py` module. We can quickly see that there is a reference to `np` in each of the methods, so we need to add our `numpy` import statement again. We also see references to `plt` which was the name given to `matplotlib.pyplot` when it was imported. Add imports of the external libraries to the top of the `visualize.py` module. Of course, don't forget our "unused import" for 3D axes.
+As a second example, let us look at the `visualize.py` module. We can quickly see that there is a reference to `np` in
+each of the methods, so we need to add our `numpy` import statement again. We also see references to `plt` which was the
+name given to `matplotlib.pyplot` when it was imported. Add imports of the external libraries to the top of
+the `visualize.py` module. Of course, don't forget our "unused import" for 3D axes.
+
 ```
 import numpy as np
 import matplotlib.pyplot as plt
@@ -406,21 +461,32 @@ from mpl_toolkits.mplot3d import Axes3D  # noqa: F401
 ```
 {: .language-python}
 
-If you use `flake8` (or if you carefully inspect), you will also see that `atom_colors` is missing. The `draw_molecule` function uses the `atom_colors` dictionary. When all of our code was in a single module, we could simply reference the dictionary by name and use it. However, we have now moved `atom_colors` and `atomic_weights` into a separate module. In order to reference the dictionaries in `visualize.py`, we need to import them using an import statement. This is an intra-package import, meaning that we are importing modules from within our packages to other imports in our package (see intra package imports [here](https://docs.python.org/3/tutorial/modules.html))
+If you use `flake8` (or if you carefully inspect), you will also see that `atom_colors` is missing. The `draw_molecule`
+function uses the `atom_colors` dictionary. When all of our code was in a single module, we could simply reference the
+dictionary by name and use it. However, we have now moved `atom_colors` and `atomic_weights` into a separate module. In
+order to reference the dictionaries in `visualize.py`, we need to import them using an import statement. This is an
+intra-package import, meaning that we are importing modules from within our packages to other imports in our package (
+see intra package imports [here](https://docs.python.org/3/tutorial/modules.html))
 
 ```
 from .atom_data import atom_colors
 ```
 {: .language-python}
 
-This import statement looks a bit different from the other import statements in our code, we have a `.` before the name. This is because it is a *relative import*. Just like when using bash, a dot (.) means to look in the current folder. 
+This import statement looks a bit different from the other import statements in our code, we have a `.` before the name.
+This is because it is a *relative import*. Just like when using bash, a dot (.) means to look in the current folder.
 
 To think about this more, lets first look at the dot in a different import statement:
+
 ```
 import matplotlib.pyplot as plt
 ```
 {: .language-python}
-In this case, the `.` is saying look within the package `matplotlib` and grab the subpackage (or module) `pyplot`. In our case, we are not using a name before the `.` so where is it looking? It is looking within the current package/directory, or in this case `molecool` for a module or package named `atom_data`, from which it will import the `atom_colors` dictionary.
+
+In this case, the `.` is saying look within the package `matplotlib` and grab the subpackage (or
+module) `pyplot`. In our case, we are not using a name before the `.` so where is it looking? It is looking within the
+current package/directory, or in this case `molecool` for a module or package named `atom_data`, from which it will
+import the `atom_colors` dictionary.
 
 
 > ## Check your understanding
@@ -435,6 +501,7 @@ In this case, the `.` is saying look within the package `matplotlib` and grab th
 {: .challenge}
 
 ### Fixing Package Imports - what is `__init__.py`?
+
 Currently, your `__init__.py` file should look like this:
 
 ~~~
@@ -456,7 +523,9 @@ del get_versions, versions
 ~~~
 {: .language-python}
 
-We have moved all of our functions into modules, but we haven't changed our `__init__.py` file. If you use a python interpreter in a directory which is not directly above your project, you can see the consequences of this. We can use the `dir` functions to see what is available in a particular module or object:
+We have moved all of our functions into modules, but we haven't changed our `__init__.py` file. If you use a python
+interpreter in a directory which is not directly above your project, you can see the consequences of this. We can use
+the `dir` functions to see what is available in a particular module or object:
 
 ~~~
 >>> import molecool
@@ -471,7 +540,9 @@ You should see something similar to the following
 ~~~
 {: .output}
 
-These are all of the things available to us from importhing `molecool`. You will see your `functions` module, but you will also see `np` and `plt`. This comes from using `from .functions import *` and is why using `import *` is usually considered a bad practice. You will notice that we cannot call `molecool.measure.calculate_distance`
+These are all of the things available to us from importhing `molecool`. You will see your `functions` module, but you
+will also see `np` and `plt`. This comes from using `from .functions import *` and is why using `import *` is usually
+considered a bad practice. You will notice that we cannot call `molecool.measure.calculate_distance`
 
 ~~~
 help(molecool.measure.calculate_distance)
@@ -493,7 +564,9 @@ help(molecool.measure.calculate_distance)
 ~~~
 {: .language-python}
 
-To change this behavior, we will need to modify our `__init__.py` file. The `__init__.py` file contains python code that is called when a module is imported. We edit it to import modules when the package loads so that functions in the `measure.py` module (for example) will be imported when the package is first imported. 
+To change this behavior, we will need to modify our `__init__.py` file. The `__init__.py` file contains python code that
+is called when a module is imported. We edit it to import modules when the package loads so that functions in
+the `measure.py` module (for example) will be imported when the package is first imported.
 
 Modify your `__init__.py` file:
 
@@ -506,9 +579,11 @@ from .visualize import draw_molecule, bond_histogram
 ~~~
 {: .language-python}
 
-Now the behavior should be the same as before. You can also delete `functions.py` if you would like since we no longer have functions in that file (you must also delete it from your `__init__.py` file, of course.)
+Now the behavior should be the same as before. You can also delete `functions.py` if you would like since we no longer
+have functions in that file (you must also delete it from your `__init__.py` file, of course.)
 
-We haven't yet included our `io` subpackage, meaning that the user would have to import this package if they wanted to use it. For example, to use the xyz functions
+We haven't yet included our `io` subpackage, meaning that the user would have to import this package if they wanted to
+use it. For example, to use the xyz functions
 
 ~~~
 import molecool.io.xyz
@@ -516,9 +591,12 @@ dir(molecool.io.open_xyz)
 ~~~
 {: .language-python}
 
-This will work, however, the main reason we broke up the modules within the `io` package was for development convenience. Right now this has come at the cost of slightly more complicated import statements to get access to any function.
+This will work, however, the main reason we broke up the modules within the `io` package was for development
+convenience. Right now this has come at the cost of slightly more complicated import statements to get access to any
+function.
 
-We can, of course, edit our `__init__.py` file to make this simpler. At this point, the way we actually do this import is going to be stylistic - how do you want people to interact with your package?
+We can, of course, edit our `__init__.py` file to make this simpler. At this point, the way we actually do this import
+is going to be stylistic - how do you want people to interact with your package?
 
 The goal we are going to go for is to call an IO function using:
 
@@ -529,14 +607,19 @@ molecool.io.IO_FUNCTION
 
 where `IO_FUNCTION` is any function relating to IO.
 
-Within the `io` directory, create a new file called `__init__.py`. Open that file within your desired editor and add the following two lines:
+Within the `io` directory, create a new file called `__init__.py`. Open that file within your desired editor and add the
+following two lines:
+
 ```
 from .pdb import open_pdb
 from .xyz import open_xyz, write_xyz
 ```
 {: .language-python}
 
-These lines are relative import statements to the functions within the `io` package. Think of them as pointers to the functions, i.e. when we look at the `io` package, it directs us to the location of the underlying functions, so we do not need to look within each submodule. This allows us to use the following import statement to our top level `__init__.py` to access the functions:
+These lines are relative import statements to the functions within the `io` package. Think of them as pointers to the
+functions, i.e. when we look at the `io` package, it directs us to the location of the underlying functions, so we do
+not need to look within each submodule. This allows us to use the following import statement to our top
+level `__init__.py` to access the functions:
 
 ```
 from . import io
@@ -550,7 +633,8 @@ We can now call our IO functions using our target syntax.
 ~~~
 {: .language-python}
 
-If we wanted the io functions to mimic the imports from the rest of the modules, we could modify our top level `__init__.py` file to reflect that.
+If we wanted the io functions to mimic the imports from the rest of the modules, we could modify our top
+level `__init__.py` file to reflect that.
 
 ~~~
 from .functions import *
@@ -561,16 +645,17 @@ from .io import open_pdb, open_xyz, write_xyz
 ~~~
 {: .language-python}
 
-
 And we could even make these functions more accessible by removing the need for the  `io`
 
 Which would allow us to call functions by simply typing
+
 ~~~
 >>> molecool.open_pdb()
 ~~~
 {: .language-python}
 
-You can now appreciate how the `init` file plays such an important role in defining how the user imports the functions in the package. 
+You can now appreciate how the `init` file plays such an important role in defining how the user imports the functions
+in the package.
 
 [package setup]: https://molssi-education.github.io/python-package-best-practices/01-package-setup/index.html
 [PEP8]: https://www.python.org/dev/peps/pep-0008/

--- a/_episodes/06-collaboration.md
+++ b/_episodes/06-collaboration.md
@@ -16,34 +16,49 @@ keypoints:
 
 ## Repository collaborators
 
-Now that we know the basics of git, we might want to know about code collaboration. There are several ways for people to contribute to your project. If you are working with a small number of people who you know well, you may simply choose to add them as collaborators to your repo. This will give them the ability to push to your repository.
+Now that we know the basics of git, we might want to know about code collaboration. There are several ways for people to
+contribute to your project. If you are working with a small number of people who you know well, you may simply choose to
+add them as collaborators to your repo. This will give them the ability to push to your repository.
 
-To add collaborators to your project, navigate to your repository on GitHub
-Click the "Settings" button to the right of the little gear.
-This will take you to some options that will help you to maintain your repository.
+To add collaborators to your project, navigate to your repository on GitHub Click the "Settings" button to the right of
+the little gear. This will take you to some options that will help you to maintain your repository.
 
 This page lets you do several important things, including rename, relocate, transfer, or delete your repository.
 
-Underneath the "Features" heading you will notice an option to "Restrict editing to collaborators only".
-This option prevents random strangers from being able to push changes to your repository, and should always be kept on.
-To allow other people to work with you, you can assign collaborators.
-Click the "Manage access" tab on the left. This will bring up a page where you can see some details about your repository. The box under the heading "Manage access" will allow you to invite collaborators to your project.
+Underneath the "Features" heading you will notice an option to "Restrict editing to collaborators only". This option
+prevents random strangers from being able to push changes to your repository, and should always be kept on. To allow
+other people to work with you, you can assign collaborators. Click the "Manage access" tab on the left. This will bring
+up a page where you can see some details about your repository. The box under the heading "Manage access" will allow you
+to invite collaborators to your project.
 
-A pop up with a search bar will appear where you can search for the names of other github users.
-By finding someone using the search bar and then clicking "Add collaborator", you can allow specific people to contribute to your project.
-Generally speaking, you should only list someone as a collaborator if you work with them closely and trust that they won't do anything especially unwise with your repository.
+A pop up with a search bar will appear where you can search for the names of other github users. By finding someone
+using the search bar and then clicking "Add collaborator", you can allow specific people to contribute to your project.
+Generally speaking, you should only list someone as a collaborator if you work with them closely and trust that they
+won't do anything especially unwise with your repository.
 
-Adding them to the repository as a collaborator will allow them to push to the repository the same way you do. 
+Adding them to the repository as a collaborator will allow them to push to the repository the same way you do.
 
-People you don't know very well shouldn't be listed as collaborators, but there are still ways for them to contribute improvements to your project.
+People you don't know very well shouldn't be listed as collaborators, but there are still ways for them to contribute
+improvements to your project.
 
 ### Protecting your main Branch
-If you choose to work with collaborators, there are still ways for you to protect your code. Click the "Branches" tab. You will see a heading which says "Branch protection rule". Adding the name of a branch here will make it a "protected branch" and the rules you choose in the section below will protect the branch (under the heading "protect matching branches"). For example, you may want to choose to protect the `main` branch so that pull requests and reviews are required to change the branch. This way, your collaborators will not be able to push to the main branch, and must submit a `pull request` more on this later in order for their changes to be incorporated. You can read more about branch protection [here](https://help.github.com/en/enterprise/2.18/admin/developer-workflow/configuring-protected-branches-and-required-status-checks#enabling-a-protected-branch-for-a-repository).
+
+If you choose to work with collaborators, there are still ways for you to protect your code. Click the "Branches" tab.
+You will see a heading which says "Branch protection rule". Adding the name of a branch here will make it a "protected
+branch" and the rules you choose in the section below will protect the branch (under the heading "protect matching
+branches"). For example, you may want to choose to protect the `main` branch so that pull requests and reviews are
+required to change the branch. This way, your collaborators will not be able to push to the main branch, and must submit
+a `pull request` more on this later in order for their changes to be incorporated. You can read more about branch
+protection [here](https://help.github.com/en/enterprise/2.18/admin/developer-workflow/configuring-protected-branches-and-required-status-checks#enabling-a-protected-branch-for-a-repository)
+.
 
 ### Pull Requests - Branch and Pull Request (PR)
-Protecting your main branch will require contributors to submit their changes through a process called a Pull Request. As the repository owner, you can also change the code through a pull request on GitHub.
 
-Previously, we discussed that all changes should take place on branches. This is still true, however, we are now going to incorporate those changes through a pull request on GitHub rather than through a merge.
+Protecting your main branch will require contributors to submit their changes through a process called a Pull Request.
+As the repository owner, you can also change the code through a pull request on GitHub.
+
+Previously, we discussed that all changes should take place on branches. This is still true, however, we are now going
+to incorporate those changes through a pull request on GitHub rather than through a merge.
 
 Create a new branch in your repository to make a small change.
 
@@ -64,9 +79,12 @@ $ git commit -m "add collaboration instructions to readme"
 ~~~
 {: .language-bash}
 
-We want these changes incorporated into the main branch. You could do as we did before and switch to the `main` branch, `merge` then changes, and push to GitHub for the changes to be present there on the `main` branch. If you are the repository owner, this will work even if you have branch protection rules. However, if you are not, your push from main will be rejected by GitHub.
+We want these changes incorporated into the main branch. You could do as we did before and switch to the `main`
+branch, `merge` then changes, and push to GitHub for the changes to be present there on the `main` branch. If you are
+the repository owner, this will work even if you have branch protection rules. However, if you are not, your push from
+main will be rejected by GitHub.
 
-We will want to push to a new branch on the repo then open a pull request. 
+We will want to push to a new branch on the repo then open a pull request.
 
 ~~~
 $ git push origin collab_instructions
@@ -92,38 +110,62 @@ To https://github.com/YOUR_USERNAME/molecool.git
 ~~~
 {: .output}
 
-This message tells you that a new branch has been created on your repository, and also tells you that you may want to open a pull request. You can click this link or copy and paste it to open a pull request. Write a description of the pull request in the box, then click "Create Pull Request".
+This message tells you that a new branch has been created on your repository, and also tells you that you may want to
+open a pull request. You can click this link or copy and paste it to open a pull request. Write a description of the
+pull request in the box, then click "Create Pull Request".
 
-Once the PR is created, you will see a page describing the PR. On the top of the repo, you should see a button called "Pull Requests" and it should show that one is open for your repo. You can then choose to review the PR, or in this case you can just merge it without a review. To review a PR, click the 'Files changed' tab. You can review the changes (green Review changes button). Since you are looking at your own PR, you won't be able to "Approve" if you have put in the branch protection rule. However, you can comment on and merge the changes if you wish.
+Once the PR is created, you will see a page describing the PR. On the top of the repo, you should see a button called "
+Pull Requests" and it should show that one is open for your repo. You can then choose to review the PR, or in this case
+you can just merge it without a review. To review a PR, click the 'Files changed' tab. You can review the changes (green
+Review changes button). Since you are looking at your own PR, you won't be able to "Approve" if you have put in the
+branch protection rule. However, you can comment on and merge the changes if you wish.
 
-This kind of workflow is fine if you and everyone contributing has write access to the repo. However, this will sometimes not be the case and you will want to contribute to repos where you do not have write access. In the next couple of sections, we will explore how this works in detail.
+This kind of workflow is fine if you and everyone contributing has write access to the repo. However, this will
+sometimes not be the case and you will want to contribute to repos where you do not have write access. In the next
+couple of sections, we will explore how this works in detail.
 
 ## Forks
 
-We have seen how it is possible to allow other people to contribute to a project by listing them as collaborators.  This works fine for a project that only a handful of people work on, but what about large open-source projects that might have hundreds of people who are interested in adding their own features?  No one wants to add all of those names to the list of collaborators, and giving everyone who asks the ability to push anything they want to the repository is guaranteed to lead to problems.  The solution to this question comes in the form of “forks.”
+We have seen how it is possible to allow other people to contribute to a project by listing them as collaborators. This
+works fine for a project that only a handful of people work on, but what about large open-source projects that might
+have hundreds of people who are interested in adding their own features? No one wants to add all of those names to the
+list of collaborators, and giving everyone who asks the ability to push anything they want to the repository is
+guaranteed to lead to problems. The solution to this question comes in the form of “forks.”
 
-Unfortunately, the word “fork” has multiple possible meanings in the context of open-source software development.
-Once upon a time, open-source software developers used the word “fork” to refer to the idea of taking an existing software project, making a copy of it, changing the name, and then developing it completely independently of the original project.
-For the purpose of this discussion, every time we use the word “fork,” we mean what happens when you push the fork button in GitHub.
+Unfortunately, the word “fork” has multiple possible meanings in the context of open-source software development. Once
+upon a time, open-source software developers used the word “fork” to refer to the idea of taking an existing software
+project, making a copy of it, changing the name, and then developing it completely independently of the original
+project. For the purpose of this discussion, every time we use the word “fork,” we mean what happens when you push the
+fork button in GitHub.
 
-A fork is a copy of a repository that is largely independent of the original.
-The maintainer of the original repository doesn’t have to do anything or know about the existence of the fork.
-Want to make changes to an open-source project, but aren’t listed as a collaborator on the project?  Just make a fork, which you own and can manage in the same way as any other repository that you create on GitHub.
-If you want to submit changes to the project’s official repository, you can create a “pull request”, which we will discuss in more detail in the next section.
+A fork is a copy of a repository that is largely independent of the original. The maintainer of the original repository
+doesn’t have to do anything or know about the existence of the fork. Want to make changes to an open-source project, but
+aren’t listed as a collaborator on the project? Just make a fork, which you own and can manage in the same way as any
+other repository that you create on GitHub. If you want to submit changes to the project’s official repository, you can
+create a “pull request”, which we will discuss in more detail in the next section.
 
 For now, we will learn how to create and maintain a fork.
 
-During this section, we will all fork a central repository, make changes, then submit something called a Pull Request to have those changes incorporated into the code. We will leave the package we are developing for this section.
+During this section, we will all fork a central repository, make changes, then submit something called a Pull Request to
+have those changes incorporated into the code. We will leave the package we are developing for this section.
 
-Navigate to the URL https://github.com/molssi-education/periodic-table in your web browser. You should see a GitHub repo. This repository contains code to make a website which has the periodic table. View the website https://molssi-education.github.io/periodic-table/ . On the website page, elements which appear with a red background have a page and information filled in. You can read more about each element by clicking on it. Elements with a white background do not yet have a page. Take a minute or two to click around. 
+Navigate to the URL https://github.com/molssi-education/periodic-table in your web browser. You should see a GitHub
+repo. This repository contains code to make a website which has the periodic table. View the
+website https://molssi-education.github.io/periodic-table/ . On the website page, elements which appear with a red
+background have a page and information filled in. You can read more about each element by clicking on it. Elements with
+a white background do not yet have a page. Take a minute or two to click around.
 
-Create a personal fork of the repository by pressing the “Fork” button near the top right of the web interface. GitHub will copy the repository to your profile. It should automatically redirect when it's done. You should notice at the top of the page, the name of the repository has a 'fork' symbol by it. It should say 'YOUR_USERNAME/periodic-table', and under that say 'forked from molssi-education/periodic-table.'
+Create a personal fork of the repository by pressing the “Fork” button near the top right of the web interface. GitHub
+will copy the repository to your profile. It should automatically redirect when it's done. You should notice at the top
+of the page, the name of the repository has a 'fork' symbol by it. It should say 'YOUR_USERNAME/periodic-table', and
+under that say 'forked from molssi-education/periodic-table.'
 
 You can use the following diagram to visualize what you just did.
 
 <center><img src="../fig/github_workflows/github_fork.svg"></center>
 
-Then, make a clone of the fork on your personal computer. Before you make the clone, MAKE SURE YOU ARE NOT IN A GIT REPOSITORY.
+Then, make a clone of the fork on your personal computer. Before you make the clone, MAKE SURE YOU ARE NOT IN A GIT
+REPOSITORY.
 
 Type
 
@@ -149,14 +191,16 @@ $ cd periodic-table
 ~~~
 {: .bash}
 
-Now, when we visualize what our repositories look like, we have a copy of our fork on our local machine. 
+Now, when we visualize what our repositories look like, we have a copy of our fork on our local machine.
 
 <center><img src="../fig/github_workflows/github_clone_fork.svg"></center>
 
 In a real development situation, we would also create a new `conda` environment for developing in this repository.
 
 ## Adding an upstream to our forks
+
 In your terminal window, type
+
 ~~~
 $ git remote -v
 ~~~
@@ -170,13 +214,16 @@ origin https://github.com/YOUR_GITHUB_USERNAME/periodic-table.git (push)
 ~~~
 {: .language-bash}
 
-This is similar to our own repository. However, since this is fork, we will want to add another remote to track the original repository. The standard names for remotes are `origin` for the repository we have cloned from, and `upstream` for the repository we forked from. Add an upstream using the following command
+This is similar to our own repository. However, since this is fork, we will want to add another remote to track the
+original repository. The standard names for remotes are `origin` for the repository we have cloned from, and `upstream`
+for the repository we forked from. Add an upstream using the following command
 
 ~~~
 $ git remote add upstream https://github.com/molssi-education/periodic-table.git
 ~~~
 
-Now, when you check the remotes (`git remote -v`), it should list both the `origin`, and `upstream` repositories. If we wanted to pull changes from the original repo, we could do `git pull upstream branch_name`
+Now, when you check the remotes (`git remote -v`), it should list both the `origin`, and `upstream` repositories. If we
+wanted to pull changes from the original repo, we could do `git pull upstream branch_name`
 
 <center><img src="../fig/github_workflows/github_remotes.svg"></center>
 
@@ -187,26 +234,33 @@ $ git fetch upstream
 ~~~
 {: .bash}
 
-To get a copy of the upstream repository. This will be in a hidden branch. You should be able to see both the origin and upstream hidden branches by typing
+To get a copy of the upstream repository. This will be in a hidden branch. You should be able to see both the origin and
+upstream hidden branches by typing
 
 ~~~
 $ git branch -a
 ~~~
 {: .bash}
 
-We will use remotes/upstream/main to keep track of new changes that happen upstream that we do not have in our local main.
+We will use remotes/upstream/main to keep track of new changes that happen upstream that we do not have in our local
+main.
 
 # Developing a new feature - creating branches
+
 We will implement a new element for the webpage.
 
-Create a new branch in your repo with your element of choice. For this demo, I will be editing the sodium page. You should choose another element. This can either be an element that exists (red background), or an element that doesn't exist yet (white background).
+Create a new branch in your repo with your element of choice. For this demo, I will be editing the sodium page. You
+should choose another element. This can either be an element that exists (red background), or an element that doesn't
+exist yet (white background).
 
 ~~~
 $ git checkout -b sodium
 ~~~
 {: .language-bash}
 
-This command creates the branch and checks it out (the `-b` stands for `branch`). Alternatively, we could have used the commands `git branch sodium` and `git checkout sodium`. In general, your branch name should describe the feature or changes that you plan to make on the branch.
+This command creates the branch and checks it out (the `-b` stands for `branch`). Alternatively, we could have used the
+commands `git branch sodium` and `git checkout sodium`. In general, your branch name should describe the feature or
+changes that you plan to make on the branch.
 
 You will see the output
 
@@ -217,40 +271,55 @@ Switched to a new branch 'sodium'
 
 We have now created a new branch called `sodium` and checked it out.
 
-
 ## More about branching
-When creating a new feature, it is a good practice to develop each feature on a new branch in the new repository.  Branching in git is exactly what it sounds like. You can create a branch from a certain commit (when using the `git branch` command), and when you switch to that branch, it is an independent copy of the repository moving forward from that branch point. 
 
-Before branching, imagine a git commit history that looks like this. In the diagram below, each circle represents a git commit. There have been two commits, and the HEAD is currently after commit 2.
+When creating a new feature, it is a good practice to develop each feature on a new branch in the new repository.
+Branching in git is exactly what it sounds like. You can create a branch from a certain commit (when using
+the `git branch` command), and when you switch to that branch, it is an independent copy of the repository moving
+forward from that branch point.
+
+Before branching, imagine a git commit history that looks like this. In the diagram below, each circle represents a git
+commit. There have been two commits, and the HEAD is currently after commit 2.
 
 <center><img src='../fig/github_workflows/git_history_0.svg'></center>
 
-After we have created a new branch and checked it out, we can imagine our git history looking like this. The sodium branch 'branches' or starts from the point where we used the git branch command. 
+After we have created a new branch and checked it out, we can imagine our git history looking like this. The sodium
+branch 'branches' or starts from the point where we used the git branch command.
 
 <center><img src = '../fig/github_workflows/git_branch.svg'></center>
 
-Now, when we make a commit on the `sodium` branch, our changes will continue from this point, leaving the main branch unchanged. Note that we have not yet made a commit, but this diagram is for illustrative purposes.
+Now, when we make a commit on the `sodium` branch, our changes will continue from this point, leaving the main branch
+unchanged. Note that we have not yet made a commit, but this diagram is for illustrative purposes.
 
 <center><img src = "../fig/github_workflows/branch_development.svg"></center>
 
 ## The importance of branching
 
-When you are doing development, particularly on a fork (but also if you are collaborating), it is very important that all development work be done on a branch. In the case of a collaborative repository where you are pushing directly, this will allow you to do pull requests from branches (more on pull requests below), and that your code is reviewed by another developer on the project before being merged to the main branch.
+When you are doing development, particularly on a fork (but also if you are collaborating), it is very important that
+all development work be done on a branch. In the case of a collaborative repository where you are pushing directly, this
+will allow you to do pull requests from branches (more on pull requests below), and that your code is reviewed by
+another developer on the project before being merged to the main branch.
 
-The most important reason to work on a branch is to keep your main branch clean. In the workflow you are learning today, the main branch should track upstream, and only be changed by pulling from upstream. This will ensure that you **always have a working piece of software on the main branch.** It will make it easier to correct mistakes if they arise, and keep your repository clean if you have multiple collaborators. 
+The most important reason to work on a branch is to keep your main branch clean. In the workflow you are learning today,
+the main branch should track upstream, and only be changed by pulling from upstream. This will ensure that you **always
+have a working piece of software on the main branch.** It will make it easier to correct mistakes if they arise, and
+keep your repository clean if you have multiple collaborators.
 
 ## Editing our element
 
-Now it's time to edit our periodic table element. If you have picked an element which exists already, there will be a file with the name `element_name.md` where element name is the element you've chosen. If the file does not exist, create it.
+Now it's time to edit our periodic table element. If you have picked an element which exists already, there will be a
+file with the name `element_name.md` where element name is the element you've chosen. If the file does not exist, create
+it.
 
-For example, to create the sodium file, 
+For example, to create the sodium file,
 
 ~~~
 $ touch sodium.md
 ~~~
 {: .language-bash}
 
-Once the file is created, open it in your text editor of choice. It is important that every element have the following at the top of the page (note - spacing is very important!)
+Once the file is created, open it in your text editor of choice. It is important that every element have the following
+at the top of the page (note - spacing is very important!)
 
 ~~~
 ---
@@ -259,7 +328,8 @@ title: ELEMENT_NAME
 ---
 ~~~
 
-If you are creating a new page, fill in the appropriate element name. Add some text about the element below the heading. For example, our sodium page might look like the following.
+If you are creating a new page, fill in the appropriate element name. Add some text about the element below the heading.
+For example, our sodium page might look like the following.
 
 ~~~
 ---
@@ -275,7 +345,8 @@ Save your file after you edit it.
 
 ## Testing out the website
 
-If you have [jekyll](https://jekyllrb.com) installed, you can view a local copy of the webpage. This is not a necessary step. If you do not have jekyll installed, or do not wish to install Jekyll skipt this step. 
+If you have [jekyll](https://jekyllrb.com) installed, you can view a local copy of the webpage. This is not a necessary
+step. If you do not have jekyll installed, or do not wish to install Jekyll skipt this step.
 
 Execute the command
 
@@ -284,7 +355,8 @@ $ bundle exec jekyll serve
 ~~~
 {: .language-bash}
 
-in the terminal the top level of your project to render a local copy of the webpage. Naviage to the local address to view your website and make sure your new element is working. 
+in the terminal the top level of your project to render a local copy of the webpage. Naviage to the local address to
+view your website and make sure your new element is working.
 
 ## Committing the change
 
@@ -296,14 +368,20 @@ $ git commit -m "update YOUR_ELEMENT page"
 ~~~
 {: .bash}
 
-Next, we must push these changes. But, where do we want to push the changes? We would like to have our changes incorporated into the central repository, but do not have permission to push upstream. We will have to push to origin (our repository) on the `sodium` branch (or whatever branch you're working on), then we will request that the maintainers of the upstream repository incorporate our changes, or pull from our repository. This is why it is called a `Pull Request`. We are literally requesting them to pull from our repository.
+Next, we must push these changes. But, where do we want to push the changes? We would like to have our changes
+incorporated into the central repository, but do not have permission to push upstream. We will have to push to origin (
+our repository) on the `sodium` branch (or whatever branch you're working on), then we will request that the maintainers
+of the upstream repository incorporate our changes, or pull from our repository. This is why it is called
+a `Pull Request`. We are literally requesting them to pull from our repository.
 
 ~~~
 $ git push origin sodium
 ~~~
 {: .bash}
 
-Here, the last line indicates that we are pushing to `origin` (our fork) to the `sodium` branch. The branch name you type in place of sodium should match the name of the branch you are working on. If you view your repository on GitHub, you should now see that you have another branch in addition to the main branch.
+Here, the last line indicates that we are pushing to `origin` (our fork) to the `sodium` branch. The branch name you
+type in place of sodium should match the name of the branch you are working on. If you view your repository on GitHub,
+you should now see that you have another branch in addition to the main branch.
 
 <center><img src="../fig/github_workflows/push_branch.svg"></center>
 
@@ -317,37 +395,45 @@ remote:
 ~~~
 {: .output}
 
-`git` is correct. What we will want to do next is create a pull request on the original repository to get our changes incorporated.
+`git` is correct. What we will want to do next is create a pull request on the original repository to get our changes
+incorporated.
 
 ## Pull requests
 
-It is now time to incorporate the edits you have made in your fork into the original repository.
-To do this, we must create a `Pull Request`.
+It is now time to incorporate the edits you have made in your fork into the original repository. To do this, we must
+create a `Pull Request`.
 
-Navigate to the URL of your fork. You should see a highlighted area and green button which says "Compare and Pull Request". Alternatively, you can navigate to the URL given in the message where you did a push.
+Navigate to the URL of your fork. You should see a highlighted area and green button which says "Compare and Pull
+Request". Alternatively, you can navigate to the URL given in the message where you did a push.
 
-Once you are on the page that says "Open a pull request", you should see fields which ask for the name of the pull request, as well as a larger text box which has space for a description. Make the title of this pull request "add sodium page". Edit the description to describe what you have done in your pull request.
+Once you are on the page that says "Open a pull request", you should see fields which ask for the name of the pull
+request, as well as a larger text box which has space for a description. Make the title of this pull request "add sodium
+page". Edit the description to describe what you have done in your pull request.
 
 Submit the pull request.
 
-Now, the maintainers of the repository can review your material, and request changes if they feel it necessary. 
+Now, the maintainers of the repository can review your material, and request changes if they feel it necessary.
 
-Anyone can see Pull Requests on public repositories. Try reviewing a few pull requests on the periodic table repository. You can leave comments/reactions. Take a few minutes to review someone else's pull request.
+Anyone can see Pull Requests on public repositories. Try reviewing a few pull requests on the periodic table repository.
+You can leave comments/reactions. Take a few minutes to review someone else's pull request.
 
-Once your changes have been accepted, upstream will have those changes on the `main` branch. This is indicated in the figure below through the change in color of the the word 'main'. 
+Once your changes have been accepted, upstream will have those changes on the `main` branch. This is indicated in the
+figure below through the change in color of the the word 'main'.
 
 <center><img src="../fig/github_workflows/accepted_PR.svg"></center>
 
 ## Incorporating upstream changes to local
 
-After your change has been accepted to upstream, you will want to incorporate the changes into your local main branch. First, switch to your main branch.
+After your change has been accepted to upstream, you will want to incorporate the changes into your local main branch.
+First, switch to your main branch.
 
 ~~~
 $ git checkout main
 ~~~
 {: .bash}
 
-You can get changes to your local main by either doing a `git pull` from upstream main, or by doing a `git fetch` from upstream main, followed by a merge. For now, just do a pull.
+You can get changes to your local main by either doing a `git pull` from upstream main, or by doing a `git fetch` from
+upstream main, followed by a merge. For now, just do a pull.
 
 ~~~
 $ git pull upstream main
@@ -363,7 +449,7 @@ $ git push origin main
 
 Now, your upstream main and origin main should be at the same point.
 
-If you are done working with your feature branch, you can now delete it. 
+If you are done working with your feature branch, you can now delete it.
 
 ~~~
 $ git branch -d sodium
@@ -381,6 +467,7 @@ $ git push origin --delete sodium
 <center><img src="../fig/github_workflows/final.svg"></center>
 
 ## More Tutorials
+
 If you want more `git`, see the following tutorials.
 
 ### Branching

--- a/_episodes/07-testing.md
+++ b/_episodes/07-testing.md
@@ -14,56 +14,62 @@ keypoints:
 - "Try to test as much of your package as you can, but don't go overboard, most packages don't have 100% test coverage."
 ---
 
-Until now, we have been writing functions and checking their behavior using an interactive Python interpreter and manually inspecting the output. While this seems to work, it can be tedious, and prone to error. In this lesson, we'll discuss how to write tests and run them using the `pytest` testing framework.
+Until now, we have been writing functions and checking their behavior using an interactive Python interpreter and
+manually inspecting the output. While this seems to work, it can be tedious, and prone to error. In this lesson, we'll
+discuss how to write tests and run them using the `pytest` testing framework.
 
-Using a testing framework will allow us to easily define tests for all of our functions and modules, and to test these each time we make a change. This will ensure that our code is behaving the way we expect, and that we do not break any features existing in the code by making new changes.
+Using a testing framework will allow us to easily define tests for all of our functions and modules, and to test these
+each time we make a change. This will ensure that our code is behaving the way we expect, and that we do not break any
+features existing in the code by making new changes.
 
 This episode explains the importance of code testing and demonstrates the possible capabilities.
 
 ## Why testing
 
-Software should be tested regularly throughout the development cycle to ensure correct operation. Thorough testing is typically an afterthought, but for larger projects, it is essential for ensuring changes in some parts of the code do not negatively affect other parts.
+Software should be tested regularly throughout the development cycle to ensure correct operation. Thorough testing is
+typically an afterthought, but for larger projects, it is essential for ensuring changes in some parts of the code do
+not negatively affect other parts.
 
-**Software testing is checking the behavior of part of the code (such as a method, class, or a module) by comparing its expected output or behavior with the observed one.** We will explain this in more detail shortly.
+**Software testing is checking the behavior of part of the code (such as a method, class, or a module) by comparing its
+expected output or behavior with the observed one.** We will explain this in more detail shortly.
 
 ## Unit vs Regression vs Integration testing
 
 There are three main levels of testing:
 
-- **Unit tests**: the purpose is to verify that each part of the code is functioning as expected.
-Unit testing is done on smaller units (such as single functions or classes) as you work on
-your code.
-This is helpful for catching errors in uncommonly-used parts of the code. Unit tests should
-be added as new features are added, resulting in better code coverage.
-In unit tests, you are testing a part of your code independent of any other factors;
-therefore, you should avoid using the file system, databases, network, or any other
-resources unless you are testing a function directly related to that resource.
+- **Unit tests**: the purpose is to verify that each part of the code is functioning as expected. Unit testing is done
+  on smaller units (such as single functions or classes) as you work on your code. This is helpful for catching errors
+  in uncommonly-used parts of the code. Unit tests should be added as new features are added, resulting in better code
+  coverage. In unit tests, you are testing a part of your code independent of any other factors; therefore, you should
+  avoid using the file system, databases, network, or any other resources unless you are testing a function directly
+  related to that resource.
 
-- **Integration tests**: this is a more holistic approach where you test the interface
-between modules, and how they combine and integrate together.
+- **Integration tests**: this is a more holistic approach where you test the interface between modules, and how they
+  combine and integrate together.
 
-- **System tests**: where you test your system as a whole to check if it meets all the
-requirements.
+- **System tests**: where you test your system as a whole to check if it meets all the requirements.
 
-Another important type of testing is **Regression tests**. In Regression tests,
-given a known input, does the software correctly and consistently return the correct
-values? This kind of testing can catch problems in previously working code that may has been broken by new changes or new features.
+Another important type of testing is **Regression tests**. In Regression tests, given a known input, does the software
+correctly and consistently return the correct values? This kind of testing can catch problems in previously working code
+that may has been broken by new changes or new features.
 
-It is highly encouraged to have Unit tests that *cover* most of your code. It is
-also helpful to have some Integration and System tests.
+It is highly encouraged to have Unit tests that *cover* most of your code. It is also helpful to have some Integration
+and System tests.
 
-In this lesson, we are focusing on unit testing.
-Same concepts here can be applied to perform Integration tests across modules.
+In this lesson, we are focusing on unit testing. Same concepts here can be applied to perform Integration tests across
+modules.
 
 ## The pytest testing framework
 
-MolSSI recommends using the [pytest](https://pytest.org) testing framework.
-Other testing frameworks are available (such as unittest and nose tests);
-however, the combination of easy implementation, [parametrization of tests](https://docs.pytest.org/en/latest/parametrize.html),
-[fixtures](https://docs.pytest.org/en/latest/fixture.html), and [test marking](https://docs.pytest.org/en/latest/example/markers.html)
+MolSSI recommends using the [pytest](https://pytest.org) testing framework. Other testing frameworks are available (such
+as unittest and nose tests); however, the combination of easy
+implementation, [parametrization of tests](https://docs.pytest.org/en/latest/parametrize.html),
+[fixtures](https://docs.pytest.org/en/latest/fixture.html),
+and [test marking](https://docs.pytest.org/en/latest/example/markers.html)
 make `pytest` an ideal testing framework.
 
 If you don't have `pytest` installed or it's not updated to version 3, install it using:
+
 ~~~
 $ pip install -U pytest-cov
 ~~~
@@ -71,9 +77,13 @@ $ pip install -U pytest-cov
 
 ### Running our first test
 
-When we run `pytest`, it will look for directories and files which start with `test` or `test_`. It then looks inside of those files and executes any functions that begin with the word `test_`. This syntax lets pytest know that these functions are tests. If these functions do not result in an error, `pytest` counts the function as passing. If an error occurs, the test fails.
+When we run `pytest`, it will look for directories and files which start with `test` or `test_`. It then looks inside of
+those files and executes any functions that begin with the word `test_`. This syntax lets pytest know that these
+functions are tests. If these functions do not result in an error, `pytest` counts the function as passing. If an error
+occurs, the test fails.
 
-CookieCutter has already created a test for us. Let's examine this file. In a text editor, open `molecool/tests/test_molecool.py`.
+CookieCutter has already created a test for us. Let's examine this file. In a text editor,
+open `molecool/tests/test_molecool.py`.
 
 ~~~
 """
@@ -90,11 +100,16 @@ def test_molecool_imported:
 ~~~
 {: .language-python}
 
-This file begins with `test_`, and contains a single function `test_molecool`. This module will import our package, then checks to see if it has been imported correctly by checking if the package name is in the list of imported modules.
+This file begins with `test_`, and contains a single function `test_molecool`. This module will import our package, then
+checks to see if it has been imported correctly by checking if the package name is in the list of imported modules.
 
-The last line, containing the python keyword `assert`, is called an assertion. Assertions are used to check the behavior of the code during runtime. The `assert` keyword halts code execution instantly if the comparison is `False`, and does nothing if the comparison is `True`. Remember that pytest counts a test as passing if no error occurs while it is being run.
+The last line, containing the python keyword `assert`, is called an assertion. Assertions are used to check the behavior
+of the code during runtime. The `assert` keyword halts code execution instantly if the comparison is `False`, and does
+nothing if the comparison is `True`. Remember that pytest counts a test as passing if no error occurs while it is being
+run.
 
-We can see if this function works by running `pytest` in our terminal. In the top level of your package, run the following command.
+We can see if this function works by running `pytest` in our terminal. In the top level of your package, run the
+following command.
 
 ~~~
 $ pytest
@@ -115,7 +130,10 @@ molecool/tests/test_molecool.py .                    [100%]
 ~~~
 {: .output}
 
-Here, `pytest` has looked through our directory and its subdirectories for anything matching `test*`. It found the `tests` folder, and within that folder, it found the file `test_functions.py`. It then executed the function `test_molecool_imported` within that module. Since our `assertion` was `True`, our test did not result in an error and the test passed.
+Here, `pytest` has looked through our directory and its subdirectories for anything matching `test*`. It found
+the `tests` folder, and within that folder, it found the file `test_functions.py`. It then executed the
+function `test_molecool_imported` within that module. Since our `assertion` was `True`, our test did not result in an
+error and the test passed.
 
 We can see the names of the tests `pytest` ran by adding a `-v` tag to the pytest command.
 
@@ -124,8 +142,8 @@ $ pytest -v
 ~~~
 {: .language-bash}
 
-Using the command argument `-v` will result in pytest listing which tests are executed and whether they pass or not. There are a number of
-additional command line arguments to [explore](https://docs.pytest.org/en/latest/usage.html).
+Using the command argument `-v` will result in pytest listing which tests are executed and whether they pass or not.
+There are a number of additional command line arguments to [explore](https://docs.pytest.org/en/latest/usage.html).
 
 ~~~
 ============================= test session starts ==============================
@@ -144,7 +162,9 @@ Now we see that `pytest` dsiplays the test name for us, as well as `PASSED` next
 
 ## Testing our functions
 
-We will now add tests to test our functions. After dividing our package into modules, we have four modules and one subpackage. It is considered good practices to also break your tests into different files depending on the module or subpackage.
+We will now add tests to test our functions. After dividing our package into modules, we have four modules and one
+subpackage. It is considered good practices to also break your tests into different files depending on the module or
+subpackage.
 
 Create a new file called `test_measure.py` in the `tests` directory with the following contents.
 
@@ -171,7 +191,8 @@ def test_calculate_distance():
 ~~~
 {: .language-python}
 
-We have written one test in this file. In our test function `test_calculate_distance`, we defined two points. We know that these points should be a distance of 1 from one another.
+We have written one test in this file. In our test function `test_calculate_distance`, we defined two points. We know
+that these points should be a distance of 1 from one another.
 
 Run this test using `pytest`. In the terminal window, type
 
@@ -195,12 +216,16 @@ molecool/tests/test_measure.py::test_calculate_distance PASSED           [100%]
 ~~~
 {: .output}
 
-We now see that we have two tests which have been run, and they both passed. This means that our calculated distance was equal to what we set as the expected distance, and the assertion did not fail.
+We now see that we have two tests which have been run, and they both passed. This means that our calculated distance was
+equal to what we set as the expected distance, and the assertion did not fail.
 
 ### Failing tests
+
 Let's see what happens when one of the test fails.
 
-In case of test failure, Pytest will show detailed output from doing its own analysis to discover the error by inspecting your objects at runtime. Change the value of the `expected` variable in your test function to `2` and rerun the test.
+In case of test failure, Pytest will show detailed output from doing its own analysis to discover the error by
+inspecting your objects at runtime. Change the value of the `expected` variable in your test function to `2` and rerun
+the test.
 
 ~~~
 $ pytest -v
@@ -239,8 +264,9 @@ molecool/tests/test_measure.py:26: AssertionError
 ~~~
 {: .output}
 
-Pytest shows a detailed failure report, including the source code around the failing line. The line that failed is marked with `>`.
-Next, it shows the values used in the assert comparison at runtime, that is `2 == 1.0`. This runtime analysis is one of the advantages of pytest that help you debug your code.
+Pytest shows a detailed failure report, including the source code around the failing line. The line that failed is
+marked with `>`. Next, it shows the values used in the assert comparison at runtime, that is `2 == 1.0`. This runtime
+analysis is one of the advantages of pytest that help you debug your code.
 
 > ## Check Your Understanding
 > What happens if you leave your `expected_value` equal to 2, but remove the assertion? Change your assertion line to the following
@@ -315,9 +341,13 @@ def test_build_bond_list():
 ~~~
 {: .language-python}
 
-Next we must have some coordinates to test. In our Jupyter Notebook, we were reading this data from an xyz file. However, remember that for unit tests, we do not want to make our test dependent on any other functions. Therefore, we will just make up some coordinates in our test.
+Next we must have some coordinates to test. In our Jupyter Notebook, we were reading this data from an xyz file.
+However, remember that for unit tests, we do not want to make our test dependent on any other functions. Therefore, we
+will just make up some coordinates in our test.
 
-Next, there are several things we might test about this function. We could check that we find the correct number of bonds, and that those bonds are the correct length. You should write at least one test per function, but you may have multiple assertions in the same test. For example, we could write the following test for `build_bond_list`.
+Next, there are several things we might test about this function. We could check that we find the correct number of
+bonds, and that those bonds are the correct length. You should write at least one test per function, but you may have
+multiple assertions in the same test. For example, we could write the following test for `build_bond_list`.
 
 ~~~
 def test_build_bond_list():
@@ -339,7 +369,8 @@ def test_build_bond_list():
 ~~~
 {: .language-python}
 
-Here, we are asserting that the correct number of bonds were found, and next we are iterating through the dictionary to ensure that a distance of 1.4 angstrom was calculated for each bond.
+Here, we are asserting that the correct number of bonds were found, and next we are iterating through the dictionary to
+ensure that a distance of 1.4 angstrom was calculated for each bond.
 
 ### Testing Expected Exceptions
 
@@ -360,7 +391,8 @@ if min_bond < 0:
 
 We can test that this `ValueError` is raised in our testing functions.
 
-In the `test_molecule.py` file, copy and modify your first test to check for this. Note that you must alter your imports to also `import pytest`.
+In the `test_molecule.py` file, copy and modify your first test to check for this. Note that you must alter your imports
+to also `import pytest`.
 
 ~~~
 import pytest
@@ -384,9 +416,12 @@ The test will pass if the `build_bond_list` method raises a 'TypeError', otherwi
 
 ## Test Driven Development - TDD - Homework Assignment
 
-Sometimes, tests are written before code is actually written. This is called "Test Driven Development" or TDD. In this case, you would write tests which define the behavior of your code, run the tests to see they pass, then write code to pass each test. TDD is common when developing a library with well-defined interfaces and features.
+Sometimes, tests are written before code is actually written. This is called "Test Driven Development" or TDD. In this
+case, you would write tests which define the behavior of your code, run the tests to see they pass, then write code to
+pass each test. TDD is common when developing a library with well-defined interfaces and features.
 
-TDD has another benefit of never having false positives. If you ensure that your tests first fail THEN pass, you know that you have really written a function that works and that your test is not just passing by default.
+TDD has another benefit of never having false positives. If you ensure that your tests first fail THEN pass, you know
+that you have really written a function that works and that your test is not just passing by default.
 
 > ## Exercise (Homework Assignment #1)
 > For this homework assignment, you are given a function specification and a test. You should write a function to make the test pass.
@@ -580,7 +615,10 @@ TDD has another benefit of never having false positives. If you ensure that your
 {: .callout}
 
 ### Pytest Marks
-Pytest marks allow you to mark your functions. There are built in marks for pytest and you can also define your own marks. Marks are implemented using decorators. One of the built-in marks in pytest is `@pytest.mark.skip`. Modify your `test_calculate_distance` function to use this mark.
+
+Pytest marks allow you to mark your functions. There are built in marks for pytest and you can also define your own
+marks. Marks are implemented using decorators. One of the built-in marks in pytest is `@pytest.mark.skip`. Modify
+your `test_calculate_distance` function to use this mark.
 
 When you run your tests, you will see that this test is now skipped:
 
@@ -591,7 +629,8 @@ molecool/tests/test_measure.py::test_calculate_distance SKIPPED
 
 You might also use the `pytest.mark.xfail` if you expect a test to fail.
 
-You can also define your own marks. Let's consider if some of our tests were slow or took a long time. Maybe we would not want to run these tests every time. We could add our own mark
+You can also define your own marks. Let's consider if some of our tests were slow or took a long time. Maybe we would
+not want to run these tests every time. We could add our own mark
 
 ~~~
 @pytest.mark.slow
@@ -623,14 +662,17 @@ $ pytest -v -m "not slow"
 ~~~
 {: .language-bash}
 
-
 ### Pytest Fixtures
 
-In your `test_molecule` module, you may have noticed that you kept having to create coordinates and symbols over and over again in each test. For this particular case, you could use a global variable, but a better approach is to create something called a `pytest fixture`. 
+In your `test_molecule` module, you may have noticed that you kept having to create coordinates and symbols over and
+over again in each test. For this particular case, you could use a global variable, but a better approach is to create
+something called a `pytest fixture`.
 
-Fixtures are resources that tests can repeatedly request to use. Fixtures can be used for dependency injection (a way of passing or supplying resources from one object to another) which help decouple the code and make it cleaner.
+Fixtures are resources that tests can repeatedly request to use. Fixtures can be used for dependency injection (a way of
+passing or supplying resources from one object to another) which help decouple the code and make it cleaner.
 
-To use fixtures, we need to import `pytest` and use the `@pytest.fixture` decorator. Fixtures can be defined as methods, where the name of the method is the name of this resource, and the returned data is its value.
+To use fixtures, we need to import `pytest` and use the `@pytest.fixture` decorator. Fixtures can be defined as methods,
+where the name of the method is the name of this resource, and the returned data is its value.
 
 ~~~
 @pytest.fixture
@@ -641,8 +683,8 @@ def methane_molecule():
 ~~~
 {: .language-python}
 
-we defined a fixture named `methane_molecule` which has symbols and coordinates. Now, any test
-method can request this fixture by adding its name to its input argument. For example, our `test_molecular_mass` function becomes.
+we defined a fixture named `methane_molecule` which has symbols and coordinates. Now, any test method can request this
+fixture by adding its name to its input argument. For example, our `test_molecular_mass` function becomes.
 
 ~~~
 def test_molecular_mass(methane_molecule):
@@ -725,7 +767,8 @@ def test_center_of_mass(methane_molecule):
 
 #### Fixture Scope
 
-By default the fixture has the scope of "function". This means a new object is created for each test function. For example, consider adding the following test which moves the carbon atom in our methane molecule.
+By default the fixture has the scope of "function". This means a new object is created for each test function. For
+example, consider adding the following test which moves the carbon atom in our methane molecule.
 
 ~~~
 def test_move_methane(methane_molecule):
@@ -737,7 +780,9 @@ def test_move_methane(methane_molecule):
 
 When you run your tests, you will see that everything passes
 
-If you have an "expensive" fixture (one that takes a lot of time to generate), you may want to change this so that the fixture is created fewer times. You can do this by adding the `scope` argument to the fixture. One scope we might pick is `module`, meaning that a new fixture will be created for each testing module.
+If you have an "expensive" fixture (one that takes a lot of time to generate), you may want to change this so that the
+fixture is created fewer times. You can do this by adding the `scope` argument to the fixture. One scope we might pick
+is `module`, meaning that a new fixture will be created for each testing module.
 
 ~~~
 @pytest.fixture(scope="module")
@@ -755,17 +800,22 @@ def methane_molecule():
 ~~~
 {: .language-python}
 
-Notice that now when you run your tests, the `build_bond_list` test will fail. This is because the `move_methane` test moved the carbon atom and since the scope was module, it remained moved for the following tests. 
+Notice that now when you run your tests, the `build_bond_list` test will fail. This is because the `move_methane` test
+moved the carbon atom and since the scope was module, it remained moved for the following tests.
 
-The `scope` keyword can be helpful for saving time, however, be aware if you are changing properties of the fixture in other tests!
+The `scope` keyword can be helpful for saving time, however, be aware if you are changing properties of the fixture in
+other tests!
 
 > ## Using fixtures across different test files
 > If during implementing your tests you realize that you want to use a fixture function from multiple test files you can move it to a conftest.py file. You don’t need to import the fixture you want to use in a test, it automatically gets discovered by pytest. Read more about this [here](https://www.tutorialspoint.com/pytest/pytest_conftest_py.htm).
-{: .callout}
+> {: .callout}
 
 ### Pytest Parametrize
 
-For some of our functions like `calculate_distance` or `calculate_angle`, we have only tested one measurement so far. This is not very complete, and we may be missing testing edge cases. You may think of writing another test where you change the values which you input into the calculation. This is definitely something you can do, but `pytest` has a feature which makes it easy to run a test with multiple inputs/values - the `parametrize` mark.
+For some of our functions like `calculate_distance` or `calculate_angle`, we have only tested one measurement so far.
+This is not very complete, and we may be missing testing edge cases. You may think of writing another test where you
+change the values which you input into the calculation. This is definitely something you can do, but `pytest` has a
+feature which makes it easy to run a test with multiple inputs/values - the `parametrize` mark.
 
 > ## Edge and Corner Cases
 > 
@@ -793,7 +843,8 @@ def test_name(variable_name1, variable_name2, ... variable_nameN, expected_answe
 ~~~
 {: .language-python}
 
-Where each line in the middle (in parenthesis) gives a set of values for the test. Then, these variables are passed to the test written under the decorator.
+Where each line in the middle (in parenthesis) gives a set of values for the test. Then, these variables are passed to
+the test written under the decorator.
 
 For example, for testing our `calculate_angle` function, we might test several angles at one time.
 
@@ -811,7 +862,8 @@ def test_calculate_angle_many(p1, p2, p3, expected_angle):
 ~~~
 {: .language-python}
 
-Run these tests, but this time add another special option to pytest `-k` which allows you to specify the name of the test you want to run.
+Run these tests, but this time add another special option to pytest `-k` which allows you to specify the name of the
+test you want to run.
 
 ~~~
 $ pytest -v -k "test_calculate_angle_many"
@@ -835,7 +887,6 @@ molecool/tests/test_measure.py::test_calculate_angle_many[p12-p22-p32-30] PASSED
 
 Running this test resulted in three different tests with three different values.
 
-
 To get all combinations of multiple parametrized arguments you can stack parametrize decorators:
 
 ~~~
@@ -847,15 +898,17 @@ def test_foo(x, y):
 ~~~
 {: .python}
 
-This will run the test with the arguments set to x=0/y=2, x=1/y=2, x=0/y=3,
-and x=1/y=3 exhausting parameters in the order of the decorators.
+This will run the test with the arguments set to x=0/y=2, x=1/y=2, x=0/y=3, and x=1/y=3 exhausting parameters in the
+order of the decorators.
 
 ### Testing Documentation Examples
-As our package changes over time, we want to make sure that the examples in our docstrings still behave as originally written, but checking these by hand can be a real pain.
-Luckily, `pytest` has a feature that will look for examples in docstrings and run them as tests.
 
-`pytest` searches the docstrings for the Python shell code, which it executes and compares to the outputs in the docstring.
-For example, in the docstring of our function `calculate_distance` we have:
+As our package changes over time, we want to make sure that the examples in our docstrings still behave as originally
+written, but checking these by hand can be a real pain. Luckily, `pytest` has a feature that will look for examples in
+docstrings and run them as tests.
+
+`pytest` searches the docstrings for the Python shell code, which it executes and compares to the outputs in the
+docstring. For example, in the docstring of our function `calculate_distance` we have:
 
 ~~~
 >>> r1 = np.array([0, 0, 0])
@@ -865,10 +918,12 @@ For example, in the docstring of our function `calculate_distance` we have:
 ~~~
 {: .language-python}
 
-`pytest` will find and execute this code (indicated by `>>>`).
-If the output is not `0.1`, `pytest` will treat the test as a failure.
+`pytest` will find and execute this code (indicated by `>>>`). If the output is not `0.1`, `pytest` will treat the test
+as a failure.
 
-We can test docstrings by adding the option `--doctest-modules`. If you are in the top level of your project, you will have to also give the name of the project folder (which is `molecool`) after the option.
+We can test docstrings by adding the option `--doctest-modules`. If you are in the top level of your project, you will
+have to also give the name of the project folder (which is `molecool`) after the option.
+
 ~~~
 $ pytest -v --doctest-modules molecool
 ~~~
@@ -898,7 +953,6 @@ molecool/tests/test_molecule.py::test_center_of_mass PASSED                     
 {: .output}
 
 The first test run is now a test of the docstring for the `calculate_distance` function.
-
 
 Change the expected answer to 0.2 in the docstring and re-run the test to get the following error:
 
@@ -945,10 +999,11 @@ Got:
 
 ### Code Coverage Pt. 1
 
-Now that we have a set of modules and associated tests, we want to see how much of our package is "covered" by our tests.
-We'll measure this by counting the lines of our packages that are touched, i.e. used, during our tests.
+Now that we have a set of modules and associated tests, we want to see how much of our package is "covered" by our
+tests. We'll measure this by counting the lines of our packages that are touched, i.e. used, during our tests.
 
-We already have everything we need for this since we installed `pytest-cov` earlier which includes the coverage tools on top of the `pytest` package.
+We already have everything we need for this since we installed `pytest-cov` earlier which includes the coverage tools on
+top of the `pytest` package.
 
 We can assess our code coverage as follows:
 
@@ -986,11 +1041,14 @@ TOTAL                       114     53    54%
 ~~~
 {: .output}
 
-The output shows how many statements (i.e. not comments) are in a file, how many weren't executed during testing, and the percentage of statements that were.
+The output shows how many statements (i.e. not comments) are in a file, how many weren't executed during testing, and
+the percentage of statements that were.
 
-To improve our coverage, we also want to see exactly which lines we missed and we can determine this using the `.coverage` file produced by `pytest`.
-Unfortunately, this strategy becomes impractical when we are working with anything larger than our test package because the `.coverage` file becomes too convoluted to read.
-We will need more tools to help us determine how to improve out tests and that will be the subject of Code Coverage pt. 2, which we will cover later in the workshop.
+To improve our coverage, we also want to see exactly which lines we missed and we can determine this using
+the `.coverage` file produced by `pytest`. Unfortunately, this strategy becomes impractical when we are working with
+anything larger than our test package because the `.coverage` file becomes too convoluted to read. We will need more
+tools to help us determine how to improve out tests and that will be the subject of Code Coverage pt. 2, which we will
+cover later in the workshop.
 
 > ## Do we need to get 100% coverage?
 >

--- a/_episodes/08-CI.md
+++ b/_episodes/08-CI.md
@@ -24,50 +24,41 @@ keypoints:
 > - Pushed up-to-date version - with tests - of the `molecool` project to GitHub.
 {: .prereq}
 
-From [Wikipedia](https://en.wikipedia.org/wiki/Continuous_integration),
-continuous integration (CI) is the practice of merging all developers' working
-copies of code to a shared mainline, several times a day. In other words, CI
-refers to the coupling of version control and unit testing in an automated way.
-Typically, CI runs either when you commit new code to your project, or
-beforehand, when you try to merge experimental code into the main repository
-(through a pull request). CI is useful not only for catching bugs before they
-reach your fellow developers and your end users, but also for expanding your
-testing to platforms that are not available to you.
+From [Wikipedia](https://en.wikipedia.org/wiki/Continuous_integration), continuous integration (CI) is the practice of
+merging all developers' working copies of code to a shared mainline, several times a day. In other words, CI refers to
+the coupling of version control and unit testing in an automated way. Typically, CI runs either when you commit new code
+to your project, or beforehand, when you try to merge experimental code into the main repository
+(through a pull request). CI is useful not only for catching bugs before they reach your fellow developers and your end
+users, but also for expanding your testing to platforms that are not available to you.
 
 Most CI services are tightly integrated with GitHub. In this episode, we will be
-using [GitHub Actions](https://docs.github.com/en/free-pro-team@latest/actions),
-because it is tightly integrated with GitHub and is free to use. Other options
-you might consider include [CircleCI](https://circleci.com), [Azure
-Pipelines](https://azure.microsoft.com/en-us/services/devops/pipelines/), or
-[Travis-CI](https://travis-ci.com/). 
+using [GitHub Actions](https://docs.github.com/en/free-pro-team@latest/actions), because it is tightly integrated with
+GitHub and is free to use. Other options you might consider include [CircleCI](https://circleci.com)
+, [Azure Pipelines](https://azure.microsoft.com/en-us/services/devops/pipelines/), or
+[Travis-CI](https://travis-ci.com/).
 
-Using any of these services is essentially getting access to empty remote
-computers that we can configure as we wish. In order to test our projects using
-Travis, we will have to set up the correct environment and tell our CI service
-what to do.
+Using any of these services is essentially getting access to empty remote computers that we can configure as we wish. In
+order to test our projects using Travis, we will have to set up the correct environment and tell our CI service what to
+do.
 
 ## Setting up GitHub Actions
-All of GitHub Actions' settings are stored in the file
-`.github/workflows/CI.yaml`. Note the leading period on the `.github` folder,
-which makes this a hidden folder in Linux and Mac OS. The `.github` file stores
-information which is relevant for GitHub in general. For example, you will also
-see in this folder a file called `CONTRIBUTING.md` which contains contributing
-guidelines (the information in this file is displayed to someone when they
-contribute to your project). The file `PULL_REQUEST_TEMPLATE.md` is the file
-which gives the template which users see when they open a pull request on your
-repository. If you wanted to change the template or contributing text, you would
-do so by editing these files. Though not included with the cookiecutter, you can
-also have an [issue
-template](https://docs.github.com/en/free-pro-team@latest/github/building-a-strong-community/configuring-issue-templates-for-your-repository).
 
-Workflows for GitHub Actions are in `.github/workflows` in yaml files.
-Fortunately for us, CookieCutter has created a file for us (`CI.yaml`) and set
-it up to run our tests with pytest. GitHub has seen this folder and has actually
-been running tests on our repository every time we push to GitHub. You might
-have noticed this, and you might have also noticed that our tests are not
-passing on GitHub despite passing locally. We will address this soon. First,
-let's go over the file `CI.yaml` in detail so you can understand what is
-happening under the hood.
+All of GitHub Actions' settings are stored in the file
+`.github/workflows/CI.yaml`. Note the leading period on the `.github` folder, which makes this a hidden folder in Linux
+and Mac OS. The `.github` file stores information which is relevant for GitHub in general. For example, you will also
+see in this folder a file called `CONTRIBUTING.md` which contains contributing guidelines (the information in this file
+is displayed to someone when they contribute to your project). The file `PULL_REQUEST_TEMPLATE.md` is the file which
+gives the template which users see when they open a pull request on your repository. If you wanted to change the
+template or contributing text, you would do so by editing these files. Though not included with the cookiecutter, you
+can also have
+an [issue template](https://docs.github.com/en/free-pro-team@latest/github/building-a-strong-community/configuring-issue-templates-for-your-repository)
+.
+
+Workflows for GitHub Actions are in `.github/workflows` in yaml files. Fortunately for us, CookieCutter has created a
+file for us (`CI.yaml`) and set it up to run our tests with pytest. GitHub has seen this folder and has actually been
+running tests on our repository every time we push to GitHub. You might have noticed this, and you might have also
+noticed that our tests are not passing on GitHub despite passing locally. We will address this soon. First, let's go
+over the file `CI.yaml` in detail so you can understand what is happening under the hood.
 
 So far in this workshop, we have been working in the `molecool/molecool` and
 `molecool/tests` directories. We will now focus on the `CI.yaml` file, in the
@@ -99,32 +90,28 @@ on:
 ~~~
 {: .yml}
 
-Before we continue, the configuration file is written in YAML and adheres to a
-set of specifications. [YAML files](https://en.wikipedia.org/wiki/YAML) they are
-very often used in software development as configuration files. For each service
-that uses a YAML, the general structure of the YAML file follows a specific
+Before we continue, the configuration file is written in YAML and adheres to a set of
+specifications. [YAML files](https://en.wikipedia.org/wiki/YAML) they are very often used in software development as
+configuration files. For each service that uses a YAML, the general structure of the YAML file follows a specific
 format, but keywords will vary depending on the application. Keywords like `on`,
-`schedule`, `push`, and `pull_request` are specific to GitHub Actions and
-indicate several steps of the entire CI process. You can always refer to the
-[documentation](https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-syntax-for-github-actions) for a list of all the avaialble
-keywords and a more in-depth explanation of each one. 
+`schedule`, `push`, and `pull_request` are specific to GitHub Actions and indicate several steps of the entire CI
+process. You can always refer to the
+[documentation](https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-syntax-for-github-actions)
+for a list of all the avaialble keywords and a more in-depth explanation of each one.
 
-This first section of the file tells GitHub what events should trigger our
-workflows to run. In this input file, we are specifying to run on pushes to the
-"main" branch or to the "master" branch. This is intended by the cookiecutter
-authors to catch both "main" and "master" since both are common as primary
-branches. If you wanted your CI to run on events to another branch, you would
-add the name here.
+This first section of the file tells GitHub what events should trigger our workflows to run. In this input file, we are
+specifying to run on pushes to the
+"main" branch or to the "master" branch. This is intended by the cookiecutter authors to catch both "main" and "master"
+since both are common as primary branches. If you wanted your CI to run on events to another branch, you would add the
+name here.
 
-GitHub Actions also allows you to run workflows [on a
-schedule](https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-syntax-for-github-actions#onschedule).
-The cookiecutter has set our workflows up to run nightly at midnight using the
-`cron` keyword. GitHub Actions allows you to specify schedules or intervals for
-running CI jobs.
+GitHub Actions also allows you to run
+workflows [on a schedule](https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-syntax-for-github-actions#onschedule)
+. The cookiecutter has set our workflows up to run nightly at midnight using the
+`cron` keyword. GitHub Actions allows you to specify schedules or intervals for running CI jobs.
 
-Next, we will tell GHA what "jobs" we want to be part of our workflow. To
-specify a job, we will need to specify the operating system on which the job
-will run, as well as other things like the Python version to use.
+Next, we will tell GHA what "jobs" we want to be part of our workflow. To specify a job, we will need to specify the
+operating system on which the job will run, as well as other things like the Python version to use.
 
 ~~~
 {% raw %}
@@ -140,47 +127,41 @@ jobs:
 ~~~
 {: .yml}
 
-In this section, we start specifying our jobs by using the "jobs" keyword. Next,
-we give the job an
+In this section, we start specifying our jobs by using the "jobs" keyword. Next, we give the job an
 [ID](https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-syntax-for-github-actions#jobsjob_id)
 (our ID here is "test"). We are using a "matrix" strategy, meaning that the job
-"test" will run many times with all combinations of variables indicated in our
-matrix. For our matrix, we are using two keywords called `os` and
-`python-version`. It should be noted that we have made these keyword names up.
-Adding keywords here with associated values just means that these are available
-as variables in the rest of our workflow. 
+"test" will run many times with all combinations of variables indicated in our matrix. For our matrix, we are using two
+keywords called `os` and
+`python-version`. It should be noted that we have made these keyword names up. Adding keywords here with associated
+values just means that these are available as variables in the rest of our workflow.
 
-To use variables in your GHA workflow you use the syntax `${{ variable_name }}`.
-You will see we have used the variables we defined in `matrix` in the job `name`
-and to specify the operating system to run on `runs-on` keyword in this section.
-This is enough for us right now, but if you would want to specify exactly which
-versions of the operative systems you wanted to run your tests on, you could!
+To use variables in your GHA workflow you use the syntax `${{ variable_name }}`. You will see we have used the variables
+we defined in `matrix` in the job `name`
+and to specify the operating system to run on `runs-on` keyword in this section. This is enough for us right now, but if
+you would want to specify exactly which versions of the operative systems you wanted to run your tests on, you could!
 
-Next, we tell GitHub Actions the `steps` which are part of our workflow. GitHub
-Actions are unique in that the CI is made up of different steps. Steps may be
-custom code which you write, but, steps may also be modular, commonly used code
-blocks which have been made available to the community. For example, many python
-projects will need to install miniconda to run. GHA makes it possible for one
-person to write this step and share it, instead of everyone having to write
-their own implmentation. Some steps in Actions are modular and can be moved
-between workflows. To see what this means, let's look at our first step.
+Next, we tell GitHub Actions the `steps` which are part of our workflow. GitHub Actions are unique in that the CI is
+made up of different steps. Steps may be custom code which you write, but, steps may also be modular, commonly used code
+blocks which have been made available to the community. For example, many python projects will need to install miniconda
+to run. GHA makes it possible for one person to write this step and share it, instead of everyone having to write their
+own implmentation. Some steps in Actions are modular and can be moved between workflows. To see what this means, let's
+look at our first step.
 
 ~~~
     steps:
     - uses: actions/checkout@v1
 ~~~
 
-This starts our `steps` section. Steps in our workflow are indicated either with
-the `uses` keyword or with the `name` keyword (will see next). If we use
-`uses,`, we are using a modular step which someone else has written and made
-available on the GitHub Actions Marketplace. It then says that it uses
-"actions/checkout@v1". This is an action which checks out your project.
-You can see the documentation [https://github.com/marketplace/actions/checkout].
-By specifying that this step uses the checkout action, we don't have to write
-code to do the checkout ourself.
+This starts our `steps` section. Steps in our workflow are indicated either with the `uses` keyword or with the `name`
+keyword (will see next). If we use
+`uses,`, we are using a modular step which someone else has written and made available on the GitHub Actions
+Marketplace. It then says that it uses
+"actions/checkout@v1". This is an action which checks out your project. You can see the
+documentation [https://github.com/marketplace/actions/checkout]. By specifying that this step uses the checkout action,
+we don't have to write code to do the checkout ourself.
 
-Next, we want to get some info about the build. This is a custom step, so we
-give it a `name` and then give the shell commands we want.
+Next, we want to get some info about the build. This is a custom step, so we give it a `name` and then give the shell
+commands we want.
 
 ~~~
 {% raw %}
@@ -194,11 +175,11 @@ give it a `name` and then give the shell commands we want.
 ~~~
 {: .yml}
 
-We then give this step a descriptive name. After we have checked out our code
-for CI, we run some bash commands to get some information about our build.
+We then give this step a descriptive name. After we have checked out our code for CI, we run some bash commands to get
+some information about our build.
 
-Next, we set up miniconda. This is a common action which many people have to do
-in their workflows, so we've used an action which is availabe on marketplace
+Next, we set up miniconda. This is a common action which many people have to do in their workflows, so we've used an
+action which is availabe on marketplace
 
 ~~~
 {% raw %}
@@ -218,26 +199,20 @@ in their workflows, so we've used an action which is availabe on marketplace
 ~~~
 {: .yml}
 
-You can go to the [specified
-URL](https://github.com/conda-incubator/setup-miniconda) to read more about this
-action. Important again to note is that the keywords given in this step are
-specific to this action. If we were setting this up ourselves, we would have had
-to find the action, read the documentation, and set up the options for the
-action to perform as we wanted. You will see we are specifying the python
-version as well as the environment file. This environment file for testing is in
-our `devtools` folder, and we will return to it soon.
+You can go to the [specified URL](https://github.com/conda-incubator/setup-miniconda) to read more about this action.
+Important again to note is that the keywords given in this step are specific to this action. If we were setting this up
+ourselves, we would have had to find the action, read the documentation, and set up the options for the action to
+perform as we wanted. You will see we are specifying the python version as well as the environment file. This
+environment file for testing is in our `devtools` folder, and we will return to it soon.
 
-Before we discuss the rest of the steps, let's consider how you might have found
-this action if the cookiecutter did not set it up for you. We've already
-mentioned the "marketplace" several times in this tutorial, so let's look at
-that. Navigate to
+Before we discuss the rest of the steps, let's consider how you might have found this action if the cookiecutter did not
+set it up for you. We've already mentioned the "marketplace" several times in this tutorial, so let's look at that.
+Navigate to
 (https://github.com/marketplace)[https://github.com/marketplace].
 
-The GitHub Marketplace is a place you can find Actions and other apps which can
-be added to your repositories. If we are using GitHub Actions and there is a
-task we are trying to achieve, it's a good idea to check the marketplace for it.
-Let's find the miniconda action by searching the marketplace. Search for "set up
-miniconda" in the marketplace.
+The GitHub Marketplace is a place you can find Actions and other apps which can be added to your repositories. If we are
+using GitHub Actions and there is a task we are trying to achieve, it's a good idea to check the marketplace for it.
+Let's find the miniconda action by searching the marketplace. Search for "set up miniconda" in the marketplace.
 
 If you search for this, you will find the action that we used. You can click on it to see the documentation.
 
@@ -263,24 +238,20 @@ dependencies:
 ~~~
 {: .yml}
 
-This is a yaml file just like our GitHub Action file (remember we said YAML is
-commonly used for configuration files). This is a file which can be used to
-create a conda environment with specified packages. For this workshop, we
-created our environment by typing the command into the terminal. This could be
-inconvenient or impossible to reproduce if we have a lot of dependencies, so
-conda allows us to specify environments using a yaml file which can be passed on
-or reused.
+This is a yaml file just like our GitHub Action file (remember we said YAML is commonly used for configuration files).
+This is a file which can be used to create a conda environment with specified packages. For this workshop, we created
+our environment by typing the command into the terminal. This could be inconvenient or impossible to reproduce if we
+have a lot of dependencies, so conda allows us to specify environments using a yaml file which can be passed on or
+reused.
 
-We can see that this file specifies what packages will be installed in this
-environment. There are the two base dependencies, `python` and `pip`, followed
-by dependencies specific to unit testing: `pytest`, `pytest-cov`, `codecov`. The
-last few lines are commented out, but allow you to install certain packages via
-`pip`, instead of `conda`. Sometimes, some dependencies are not available on any
-Conda channel but exist on [PyPI](https://pypi.org/).
+We can see that this file specifies what packages will be installed in this environment. There are the two base
+dependencies, `python` and `pip`, followed by dependencies specific to unit testing: `pytest`, `pytest-cov`, `codecov`.
+The last few lines are commented out, but allow you to install certain packages via
+`pip`, instead of `conda`. Sometimes, some dependencies are not available on any Conda channel but exist
+on [PyPI](https://pypi.org/).
 
-Next, we installed our package in our environment as a development install. We
-use `conda list` after to print the details of the environment. This way, the
-installed packages will be in the GitHub Actions log file in case you need to
+Next, we installed our package in our environment as a development install. We use `conda list` after to print the
+details of the environment. This way, the installed packages will be in the GitHub Actions log file in case you need to
 check it.
 
 ~~~
@@ -313,15 +284,12 @@ After our package is installed, we run the test:
 
 ## Getting our CI to work
 
-Unfortunately, our CI runs failed. To know more about why this was the case, we
-have to read the GitHub Action log files. Click on one of the failing entries. The new
-page you will be redirected to has details about the job at the top and then the
-contents of the log file underneath. Look for red lines that indicate errors in
-your build.
+Unfortunately, our CI runs failed. To know more about why this was the case, we have to read the GitHub Action log
+files. Click on one of the failing entries. The new page you will be redirected to has details about the job at the top
+and then the contents of the log file underneath. Look for red lines that indicate errors in your build.
 
-Our tests failed because `numpy` could not be imported. When we set up the
-dependencies, we did not explicitly write either `numpy` or `matplotlib`. As
-such, when Travis creates and configures the machines where our CI runs, these
+Our tests failed because `numpy` could not be imported. When we set up the dependencies, we did not explicitly write
+either `numpy` or `matplotlib`. As such, when Travis creates and configures the machines where our CI runs, these
 packages are never installed. We need to add them to the
 `devtools/conda-envs/test_env.yaml` file.
 
@@ -356,11 +324,10 @@ packages are never installed. We need to add them to the
 > {: .solution}
 {: .challenge}
 
-After these edits, commit and push to the repository. GitHub will now detect a
-new commit and will start a new build automatically. On your GitHub repository,
-click the Actions tab to see a new CI build running. After a
-minute or two, you should see green checkmarks next to your build jobs.
-Congratulations! GitHub Actions is now set up and tracking your repository.
+After these edits, commit and push to the repository. GitHub will now detect a new commit and will start a new build
+automatically. On your GitHub repository, click the Actions tab to see a new CI build running. After a minute or two,
+you should see green checkmarks next to your build jobs. Congratulations! GitHub Actions is now set up and tracking your
+repository.
 
 
 > ## Tests, coverage, and much much more!
@@ -385,14 +352,14 @@ Congratulations! GitHub Actions is now set up and tracking your repository.
 > Edit your `README.md` file to fix the link to the GitHub Actions CI status
 > badge. You should replace the `REPLACE_WITH_OWNER_ACCOUNT` placeholder with
 > your GitHub username. After committing, enjoy the new (hopefully green!)
-> badge! 
+> badge!
 {: .challenge}
 
 
-This repository is just for demonstration, so we probably do not want to
-actually waste resources running these tests every 24 hours. Go to your
-`CI.yaml` file and remove the scheduled jobs. You should remove the schedule
-keyword from your YAML file, so that the `on` section matches below:
+This repository is just for demonstration, so we probably do not want to actually waste resources running these tests
+every 24 hours. Go to your
+`CI.yaml` file and remove the scheduled jobs. You should remove the schedule keyword from your YAML file, so that
+the `on` section matches below:
 
 ~~~
 name: CI
@@ -413,20 +380,19 @@ on:
 {: .yml}
 
 ## Code Coverage - Part II
-In the previous episode, we introduced the concept of code coverage as a measure
-of how much of our code is run by our unit tests. Projects should aim for a high
-coverage percentage, but not obsess over the number. Remember that even if your
-project has 100% coverage, it does not mean it is actually bug-free.
+
+In the previous episode, we introduced the concept of code coverage as a measure of how much of our code is run by our
+unit tests. Projects should aim for a high coverage percentage, but not obsess over the number. Remember that even if
+your project has 100% coverage, it does not mean it is actually bug-free.
 
 When we run `pytest`, we can get a summary of our coverage with the
-`--cov=molecool` option. While this summary is helpful, it would be much more
-useful to know _which_ lines are covered by our tests. In the following section,
-we will explore two methods that allow us to do just that.
+`--cov=molecool` option. While this summary is helpful, it would be much more useful to know _which_ lines are covered
+by our tests. In the following section, we will explore two methods that allow us to do just that.
 
 ### Assessing code coverage locally
-Besides coverage summaries, the `pytest-cov` module can also produce details
-reports. Run the following command at the root of your project to generate a
-report in HTML format:
+
+Besides coverage summaries, the `pytest-cov` module can also produce details reports. Run the following command at the
+root of your project to generate a report in HTML format:
 
 ~~~
 $ pytest -v --cov=molecool --cov-report=html
@@ -434,25 +400,21 @@ $ pytest -v --cov=molecool --cov-report=html
 {: .language-bash}
 
 This command runs the tests as normal and in addition, creates a folder
-`htmlcov` that contains web pages highlighting the lines on each of our files
-that are covered by tests. Go ahead and open the file `htmlcov/index.html` on
-your web browser.
+`htmlcov` that contains web pages highlighting the lines on each of our files that are covered by tests. Go ahead and
+open the file `htmlcov/index.html` on your web browser.
 
 <br />
 <center><img src="../fig/08_CI/pytestcov_reporthtml.png"></center>
 <br />
 
-The report page shows all the modules in your project, along with the number of
-lines (statements). More importantly, it lists how many of these lines are not
-covered by tests (missing) as well as the coverage percentage. These percentages
-depends on how you wrote your functions and your tests, so don't worry if those
-of the image above are slightly different.
+The report page shows all the modules in your project, along with the number of lines (statements). More importantly, it
+lists how many of these lines are not covered by tests (missing) as well as the coverage percentage. These percentages
+depends on how you wrote your functions and your tests, so don't worry if those of the image above are slightly
+different.
 
-Click on the `measure.py` file name to see exactly which lines are missing from
-our tests. The colors indicate which lines are covered (in green) and which are
-not. We can see that in our `calculate_angle` function, the return value in
-radians is never checked by our tests. Let's go ahead and fix that by writing a
-new test.
+Click on the `measure.py` file name to see exactly which lines are missing from our tests. The colors indicate which
+lines are covered (in green) and which are not. We can see that in our `calculate_angle` function, the return value in
+radians is never checked by our tests. Let's go ahead and fix that by writing a new test.
 
 > ## Exercise
 > Write a new test in `tests/test_measure.py` to check that `calculate_angle` returns the
@@ -479,56 +441,47 @@ If you refresh the coverage page on your browser (or re-open it if you closed it
 `measure.py` now has 100% coverage.
 
 ### Adding code coverage to your CI workflow
-Besides running tests for you, GitHub can interface with other services to help
-you get reports on code coverage. In this last section, we will introduce
-[Codecov](https://codecov.io/), one of many services that was created to help
-developers assess which areas of their projects lack sufficient test coverage.
-Codecov is free for open-source projects and integrates very nicely with GitHub.
 
-On your browser, navigate again to the [GitHub
-Marketplace](https://github.com/marketplace) and this time, select the category
-`Code quality`. Find and click on `Codecov`, and on the following page install
-the `Open Source` plan. You can choose to add CodeCov to your accout here, and
-you can choose either to add it to all repositories or to slect repositories.
-After going through the install process, you will be redirected to codecov.io
-where you should log in with your GitHub Accout.
+Besides running tests for you, GitHub can interface with other services to help you get reports on code coverage. In
+this last section, we will introduce
+[Codecov](https://codecov.io/), one of many services that was created to help developers assess which areas of their
+projects lack sufficient test coverage. Codecov is free for open-source projects and integrates very nicely with GitHub.
 
-Once on the `Codecov` web page, notice that `molecool` is already in your
-repositories and it already has results to show you. How is this possible?
+On your browser, navigate again to the [GitHub Marketplace](https://github.com/marketplace) and this time, select the
+category
+`Code quality`. Find and click on `Codecov`, and on the following page install the `Open Source` plan. You can choose to
+add CodeCov to your accout here, and you can choose either to add it to all repositories or to slect repositories. After
+going through the install process, you will be redirected to codecov.io where you should log in with your GitHub Accout.
 
-The last line step of our `CI.yml` configuration file is a call to an executable
-called `codecov`. The CookieCutter includes this utility program and sets it up
-automatically for us. As a result, when our CI workflow runs successfully (all
-tests pass), GitHub Actions runs `codecov`, which send statistics of our test
-coverage automatically to Codecov.io. Neat!
+Once on the `Codecov` web page, notice that `molecool` is already in your repositories and it already has results to
+show you. How is this possible?
 
-Back to the Codecov `molecool` report page, the sunburst plot gives a
-hierachical view of our project and its coverage. 
+The last line step of our `CI.yml` configuration file is a call to an executable called `codecov`. The CookieCutter
+includes this utility program and sets it up automatically for us. As a result, when our CI workflow runs successfully (
+all tests pass), GitHub Actions runs `codecov`, which send statistics of our test coverage automatically to Codecov.io.
+Neat!
+
+Back to the Codecov `molecool` report page, the sunburst plot gives a hierachical view of our project and its coverage.
 
 <br />
 <center><img src="../fig/08_CI/codecov_screenshot.png"></center>
 <br />
 
-Red areas represent code that is poorly covered by our tests. On the right, you
-see the latest commits and can click on each one of them to see how they changed
-overall coverage of the project. It is possible, although outside the scope of
-this episode, to setup Travis to fail if a commit lowers the coverage of our
-codebase. The bottom of the page shows a simple file-browser like interface,
-much like the HTML page we obtained before.
+Red areas represent code that is poorly covered by our tests. On the right, you see the latest commits and can click on
+each one of them to see how they changed overall coverage of the project. It is possible, although outside the scope of
+this episode, to setup Travis to fail if a commit lowers the coverage of our codebase. The bottom of the page shows a
+simple file-browser like interface, much like the HTML page we obtained before.
 
 ## Modifying the Workflow - Adding an Action
 
-A great feature of GitHub Actions is that they are modular. Anyone can make
-an action and it can be plugged into someone else's workflow if it is available
-on the GitHub Marketplace. This means that if you ever need to do something
-which is something that may be commonly done, you should check the GitHub
-Marketplace to see if anyone has made this action before. 
+A great feature of GitHub Actions is that they are modular. Anyone can make an action and it can be plugged into someone
+else's workflow if it is available on the GitHub Marketplace. This means that if you ever need to do something which is
+something that may be commonly done, you should check the GitHub Marketplace to see if anyone has made this action
+before.
 
-Let's see how this works by adding a silly action to our workflow. Let's say we
-want a job on our workflow to print some ASCII art our GHA Log. Searching the
-GitHub Marketplace, you might find [this
-action](https://github.com/marketplace/actions/ascii-art-action) which generates
-ASCII art from text.
+Let's see how this works by adding a silly action to our workflow. Let's say we want a job on our workflow to print some
+ASCII art our GHA Log. Searching the GitHub Marketplace, you might
+find [this action](https://github.com/marketplace/actions/ascii-art-action) which generates ASCII art from text.
 
 > ## Exercise - Adding an Action to our Workflow
 > 

--- a/_episodes/09-documentation.md
+++ b/_episodes/09-documentation.md
@@ -12,42 +12,56 @@ keypoints:
 - "Some documentation is better than no documentation"
 ---
 
-This episode discusses documentation strategies. In particular, we will focus on how to build documentation using Sphinx and host that documentation online using ReadTheDocs.
+This episode discusses documentation strategies. In particular, we will focus on how to build documentation using Sphinx
+and host that documentation online using ReadTheDocs.
 
-Documentation must be provided to allow for use, development, and maintenance
-of software. Documentation is often overlooked by developers since it is
-tedious and boring, however good documentation is an extremely good habit to
+Documentation must be provided to allow for use, development, and maintenance of software. Documentation is often
+overlooked by developers since it is tedious and boring, however good documentation is an extremely good habit to
 develop.
 
 The documentation typically involves several components:
 
- - What your project does and why it is useful
- - Build requirements and dependencies (if applicable)
- - How to compile/build/test/install
- - How to use the software (through the API or through inputs)
- - Some examples
- - Who maintains the project
-
+- What your project does and why it is useful
+- Build requirements and dependencies (if applicable)
+- How to compile/build/test/install
+- How to use the software (through the API or through inputs)
+- Some examples
+- Who maintains the project
 
 ## README documentation
 
-So far in our project, we have added things like installation and use instructions to our `README.md` which is displayed on our GitHub repository. We have also written in-code documentation in the form of comments and function doc strings. This works well for small projects, and may be all of the documentation you need for many of your projects. However, if you are preparing a software package to be widely used, you may want to make a website for people to find information about your package.
+So far in our project, we have added things like installation and use instructions to our `README.md` which is displayed
+on our GitHub repository. We have also written in-code documentation in the form of comments and function doc strings.
+This works well for small projects, and may be all of the documentation you need for many of your projects. However, if
+you are preparing a software package to be widely used, you may want to make a website for people to find information
+about your package.
 
 ## Sphinx for complex modules
 
-When you want to improve your documentation strategies for Python packages, use [Sphinx](https://www.sphinx-doc.org/en/master/). Sphinx is a tool for creating documentation and was originally created for documentation of the Python programming language.
+When you want to improve your documentation strategies for Python packages,
+use [Sphinx](https://www.sphinx-doc.org/en/master/). Sphinx is a tool for creating documentation and was originally
+created for documentation of the Python programming language.
 
-With Sphinx and some extensions, you can write documentation giving instructions and examples of your software AND pull out the in code documentation we have already written as docstrings to document your API. The ability to pull out in-code doc-strings as documentation is an advantage - you won't have to maintain documentation in two places. Later, we will see how we can automatically generate our documentation every time we push to the repository.
+With Sphinx and some extensions, you can write documentation giving instructions and examples of your software AND pull
+out the in code documentation we have already written as docstrings to document your API. The ability to pull out
+in-code doc-strings as documentation is an advantage - you won't have to maintain documentation in two places. Later, we
+will see how we can automatically generate our documentation every time we push to the repository.
 
-Many projects you are familiar with use Sphinx for documentation - including numpy, matplotlib, and pytest. To see a list of project that use Sphinx, click [here](https://www.sphinx-doc.org/en/master/examples.html).
+Many projects you are familiar with use Sphinx for documentation - including numpy, matplotlib, and pytest. To see a
+list of project that use Sphinx, click [here](https://www.sphinx-doc.org/en/master/examples.html).
 
 CookieCutter has already set up files which we need to get started with Sphinx.
 
 ### Using Sphinx to build documentation
 
-To build your Sphinx documentation locally, you will first need to install Sphinx. This command installs Sphinx, and the Sphinx Read The Docs theme (the theme you use defines the style of your pages). There are many themes available for Sphinx, and if you view the Sphinx [examples](https://www.sphinx-doc.org/en/master/examples.html) you will see several themes you could choose from.
+To build your Sphinx documentation locally, you will first need to install Sphinx. This command installs Sphinx, and the
+Sphinx Read The Docs theme (the theme you use defines the style of your pages). There are many themes available for
+Sphinx, and if you view the Sphinx [examples](https://www.sphinx-doc.org/en/master/examples.html) you will see several
+themes you could choose from.
 
-The command below installs the Sphinx software and a theme for your Sphinx Documentation. The cookiecutter comes preconfigured to use the [Sphinx ReadTheDocs theme](https://sphinx-rtd-theme.readthedocs.io/en/stable/) (or `sphinx_rtd_theme`), but there are many themes you can choose from if you wish. 
+The command below installs the Sphinx software and a theme for your Sphinx Documentation. The cookiecutter comes
+preconfigured to use the [Sphinx ReadTheDocs theme](https://sphinx-rtd-theme.readthedocs.io/en/stable/) (
+or `sphinx_rtd_theme`), but there are many themes you can choose from if you wish.
 
 ~~~
 $ pip install sphinx
@@ -55,7 +69,9 @@ $ pip install sphinx_rtd_theme
 ~~~
 {: .language-bash}
 
-While we work with documentation, we will finally be looking at the third directory which CookieCutter created (remember that we've looked at the project directory, and the `devtools` directory). The files which CookieCutter has set up for Sphinx are in the `docs` folder. Navigate to that directory.
+While we work with documentation, we will finally be looking at the third directory which CookieCutter created (remember
+that we've looked at the project directory, and the `devtools` directory). The files which CookieCutter has set up for
+Sphinx are in the `docs` folder. Navigate to that directory.
 
 ~~~
 $ cd docs
@@ -78,9 +94,14 @@ _static             conf.py             make.bat
 
 These are the files we will use to build our documentation.
 
-The important files for you to edit in this directory end with the extension `.rst`. These are `reStructured text` files, and they are what Sphinx will use to build each page or section of your documentation. We have three restructured text files here to begin (`index.rst`, `getting_started.rst`, `api.rst`). The included `rst` pages were generated by the cookiecutter as a starting point for you.
+The important files for you to edit in this directory end with the extension `.rst`. These are `reStructured text`
+files, and they are what Sphinx will use to build each page or section of your documentation. We have three restructured
+text files here to begin (`index.rst`, `getting_started.rst`, `api.rst`). The included `rst` pages were generated by the
+cookiecutter as a starting point for you.
 
-When you build your documentation, the `index.rst` will be the index, or main page of your documentation. The other `rst` files are examples of pages you might want to have (from CookieCutter). Any time you want to make a new page, you can create a file with an `.rst` extension.
+When you build your documentation, the `index.rst` will be the index, or main page of your documentation. The
+other `rst` files are examples of pages you might want to have (from CookieCutter). Any time you want to make a new
+page, you can create a file with an `.rst` extension.
 
 To build your documentation as html, type
 
@@ -89,7 +110,8 @@ $ make html
 ~~~
 {: .language-bash}
 
-This command tells Sphinx to generate your documentation as html pages. With this command, we are building HTML files from the reStructured text files.
+This command tells Sphinx to generate your documentation as html pages. With this command, we are building HTML files
+from the reStructured text files.
 
 Now notice when you type `ls` a some new directories have appeared.
 
@@ -105,13 +127,18 @@ _build              api.rst             getting_started.rst
 ~~~
 {: .output}
 
-In particular, notice the `_build` directory. Sphinx put the HTML files it generated here. There should now be files in your `_build/html` folder. You can open these files in your browser to preview what your documentation will look like.
+In particular, notice the `_build` directory. Sphinx put the HTML files it generated here. There should now be files in
+your `_build/html` folder. You can open these files in your browser to preview what your documentation will look like.
 
 ## Adding Information to our Documentation
 
-Noww, we will have the task of actually adding information about our project to our documentation. This part will require us to write! 
+Noww, we will have the task of actually adding information about our project to our documentation. This part will
+require us to write!
 
-When writing Sphinx documentation, you use `reStructured Text (RST)` syntax. This is similar to markdown, but has notable difference. See this [reStructured Text Cheat Sheet](https://thomas-cokelaer.info/tutorials/sphinx/rest_syntax.html) for info on reStructured Text.
+When writing Sphinx documentation, you use `reStructured Text (RST)` syntax. This is similar to markdown, but has
+notable difference. See
+this [reStructured Text Cheat Sheet](https://thomas-cokelaer.info/tutorials/sphinx/rest_syntax.html) for info on
+reStructured Text.
 
 Let's start by adding a simple a description to your `index.rst` under the first heading.
 
@@ -133,7 +160,9 @@ $ make html
 
 Refresh the page in your browser to see the page with the new description.
 
-CookieCutter has already added some other pages to our documentation, `getting_started.rst`, and `api.rst`. Let's tell someone how to get started on the 'Getting Started' page. Click the link on your HTML documentation  to see what is there already.
+CookieCutter has already added some other pages to our documentation, `getting_started.rst`, and `api.rst`. Let's tell
+someone how to get started on the 'Getting Started' page. Click the link on your HTML documentation to see what is there
+already.
 
 Right now, it says
 
@@ -145,10 +174,10 @@ To changed this, we will edit the content of `getting_started.rst`
 
 > ## Exercise - Getting Started
 > Using the [reStructred Text Cheat Sheet](https://thomas-cokelaer.info/tutorials/sphinx/rest_syntax.html), add some information to your Getting Started page. Use the following guidelines
-> 
+>
 > 1. Add a text description under "Getting Started".
 > 1. Create a subheading called "installation" which contains installation instructions.
-> 1.  The "Installation" secion should use a list for dependencies and a code block with the installation command.
+> 1. The "Installation" secion should use a list for dependencies and a code block with the installation command.
 >
 >> ## Solution
 >> Following the guidelines and using the cheat sheet may lead you to a page which looks like this:
@@ -176,6 +205,7 @@ To changed this, we will edit the content of `getting_started.rst`
 {: .challenge}
 
 We can also add a Python code block, for example. The Sphinx RTD Theme will use syntax highlighting for Python code.
+
 ~~~
 Usage
 -------
@@ -190,7 +220,11 @@ Once installed, you can use the package. This example draws a benzene molecule f
 
 ## Sphinx Directives
 
-The thing that really gives Sphinx special abilities are **directives**. Directives are extensions which can be used with your restructred text to add special sections, images, warnings, etc to your documentation, and are part of a package called [docutils](https://docutils.sourceforge.io/) which Sphinx is built on top of. You can see a general list of directives [here](https://www.sphinx-doc.org/en/master/usage/restructuredtext/basics.html#rst-directives), and a list of special Sphinx Directives [here](https://www.sphinx-doc.org/en/1.8/usage/restructuredtext/directives.html).
+The thing that really gives Sphinx special abilities are **directives**. Directives are extensions which can be used
+with your restructred text to add special sections, images, warnings, etc to your documentation, and are part of a
+package called [docutils](https://docutils.sourceforge.io/) which Sphinx is built on top of. You can see a general list
+of directives [here](https://www.sphinx-doc.org/en/master/usage/restructuredtext/basics.html#rst-directives), and a list
+of special Sphinx Directives [here](https://www.sphinx-doc.org/en/1.8/usage/restructuredtext/directives.html).
 
 In general, the syntax for a directive is (with appropriate options and syntax)
 
@@ -204,7 +238,10 @@ In general, the syntax for a directive is (with appropriate options and syntax)
 ~~~
 
 ### Code Highlight Directive
-One useful directive is code highlighting. Previously, we automatically highlighted our code using `::` at the end of a line followed by a blank line, then an indented line with code. We could have alternatively used a directive and specified the language.
+
+One useful directive is code highlighting. Previously, we automatically highlighted our code using `::` at the end of a
+line followed by a blank line, then an indented line with code. We could have alternatively used a directive and
+specified the language.
 
 ~~~
 .. code-block:: language
@@ -212,7 +249,7 @@ One useful directive is code highlighting. Previously, we automatically highligh
   *CODE GOES HERE*
 ~~~
 
-For our Python example, 
+For our Python example,
 
 ~~~
 .. code-block:: python
@@ -224,7 +261,10 @@ For our Python example,
     molecool.draw_molecule(benzene_coords, benzene_symbols, draw_bonds=benzene_bonds)
 ~~~
 
-The line `.. code-block:: python` is the line which starts the directive. Directives always start with two periods (`..`), followed by a space, then the directive name (`code-block` in this case), then two colons (`::`). Next, you hit enter and add any options for the directive. What we want highlighted as code is indented below this directive line.
+The line `.. code-block:: python` is the line which starts the directive. Directives always start with two
+periods (`..`), followed by a space, then the directive name (`code-block` in this case), then two colons (`::`). Next,
+you hit enter and add any options for the directive. What we want highlighted as code is indented below this directive
+line.
 
 Sphinx `code-block` directive supports many languages. For example, we could add a C++ code block.
 
@@ -241,7 +281,11 @@ Sphinx `code-block` directive supports many languages. For example, we could add
 ~~~
 
 ### The Table of Contents Directive
-The next directive we will discuss is the Table of Contents directive. Look at the file `index.rst`. It contains the `toctree` directive, which generates a special section called a Table of Contents which links to other parts of your projects. The Table of Contents on your `index.rst` file is what shows up on your main menu on the left of the page. It is also on your main page.
+
+The next directive we will discuss is the Table of Contents directive. Look at the file `index.rst`. It contains
+the `toctree` directive, which generates a special section called a Table of Contents which links to other parts of your
+projects. The Table of Contents on your `index.rst` file is what shows up on your main menu on the left of the page. It
+is also on your main page.
 
 ~~~
 .. toctree::
@@ -252,11 +296,17 @@ The next directive we will discuss is the Table of Contents directive. Look at t
    api
 ~~~
 
-This directive has an example of directive options, namely `maxdepth` and `caption`. You can think of these as arguments into a function. We then have options for depth of the the Table of Contents (what level of headers to show), as well as the "caption". You can see other options for this directive under "Additional options" on the [documentation page](https://www.sphinx-doc.org/en/1.8/usage/restructuredtext/directives.html). 
+This directive has an example of directive options, namely `maxdepth` and `caption`. You can think of these as arguments
+into a function. We then have options for depth of the the Table of Contents (what level of headers to show), as well as
+the "caption". You can see other options for this directive under "Additional options" on
+the [documentation page](https://www.sphinx-doc.org/en/1.8/usage/restructuredtext/directives.html).
 
-After the settings for the TOC tree, you list the name of the pages you want to be included in this Table of Contents. Right now, we are including the 'Getting Started' page and the API page.
+After the settings for the TOC tree, you list the name of the pages you want to be included in this Table of Contents.
+Right now, we are including the 'Getting Started' page and the API page.
 
-Note that you add the __file name__ in the TOC Tree, but the title of the page (For example, for the `Getting Started` page, the page heading ('Getting Started') is what shows up in the TOC, but you list the file name without the extension is the TOC tree `getting_started`.)
+Note that you add the __file name__ in the TOC Tree, but the title of the page (For example, for the `Getting Started`
+page, the page heading ('Getting Started') is what shows up in the TOC, but you list the file name without the extension
+is the TOC tree `getting_started`.)
 
 > ## Exercise
 > Create a new page with the title "About" that gives a description of the project. Specify that this project is for a MolSSI Best Practices Workshop, and put a link to the molssi homepage (molssi.org). Add your new page to the Table of Contents.
@@ -302,9 +352,14 @@ Note that you add the __file name__ in the TOC Tree, but the title of the page (
 
 ## Automatically Generating Documentation using Sphinx-AutoDoc
 
-To generate your documentation with the modules documented from your docstrings, we will use [Sphinx-Autodoc](https://www.sphinx-doc.org/en/master/usage/extensions/autodoc.html). AutoDoc will pull out and render your documentation strings so that they are viewable to the user. This makes maintaining code documentation easier on you, as you will only need to maintain documentation for usage of functions in one place (the source code.)
+To generate your documentation with the modules documented from your docstrings, we will
+use [Sphinx-Autodoc](https://www.sphinx-doc.org/en/master/usage/extensions/autodoc.html). AutoDoc will pull out and
+render your documentation strings so that they are viewable to the user. This makes maintaining code documentation
+easier on you, as you will only need to maintain documentation for usage of functions in one place (the source code.)
 
-CookieCutter has already added a page which uses these tools. On your index page, click `API Documentation`, then click on the `canvas` function. You will see the docstring written for the function. If you click the green 'source' button to the right, you will be taken to a page which shows the source code for the function.
+CookieCutter has already added a page which uses these tools. On your index page, click `API Documentation`, then click
+on the `canvas` function. You will see the docstring written for the function. If you click the green 'source' button to
+the right, you will be taken to a page which shows the source code for the function.
 
 Opening, the `api.rst` file, you should see the following.
 
@@ -318,7 +373,10 @@ API Documentation
    molecool.canvas
 ~~~
 
-We are using a Sphinx extension called `autosummary`.  This tells Sphinx to insert a table that contains links to documented items.  Autosummary will put `docstrings` out of functions and a page for each docstring. Under that, we are starting a Table of Contents for this page. We will list any functions we would like to have documented here. This is useful if we would like to separate our API documentation into several pages.
+We are using a Sphinx extension called `autosummary`. This tells Sphinx to insert a table that contains links to
+documented items. Autosummary will put `docstrings` out of functions and a page for each docstring. Under that, we are
+starting a Table of Contents for this page. We will list any functions we would like to have documented here. This is
+useful if we would like to separate our API documentation into several pages.
 
 For example, we can add documentation for our `calculate_distance` function.
 
@@ -355,7 +413,8 @@ API Documentation
 
 ## An Alternatre way - Automodule
 
-Alternatively, you could choose to break your module documentation into different pages. You may want to write documentation in addition to your docstring. Add a page called `measure.rst` with the following contents:
+Alternatively, you could choose to break your module documentation into different pages. You may want to write
+documentation in addition to your docstring. Add a page called `measure.rst` with the following contents:
 
 ~~~
 Measure module
@@ -374,11 +433,15 @@ I can also put additional information about a function.
 
 ## Equation Directives
 
-Our docstring for `calculate_center_of_mass` has a section where we give the formula for the center of mass. If you re-examine that docstring, you will see that it is actually specified using a Sphinx Directive. Add `calculate_center_of_mass` to your API Documentation and view the page to see the rendered equation.
+Our docstring for `calculate_center_of_mass` has a section where we give the formula for the center of mass. If you
+re-examine that docstring, you will see that it is actually specified using a Sphinx Directive.
+Add `calculate_center_of_mass` to your API Documentation and view the page to see the rendered equation.
 
 ## The `conf.py` file
 
-Now that we've worked with Sphinx, let's look a little closer at what's going on. The file `conf.py` in your `docs` folder gives all of the configuration setting we are using for Sphinx to build our documentation. CookieCutter has added several extensions to Sphinx to make the documentation we've built.
+Now that we've worked with Sphinx, let's look a little closer at what's going on. The file `conf.py` in your `docs`
+folder gives all of the configuration setting we are using for Sphinx to build our documentation. CookieCutter has added
+several extensions to Sphinx to make the documentation we've built.
 
 Open your `conf.py` file and find the `extensions` section.
 
@@ -402,14 +465,24 @@ napoleon_use_ivar = True
 ~~~
 {: .language-python}
 
-CookieCutter has added a few extensions here which will allow us to pull doc strings from our Python modules (`sphinx.ext.autosummary`, `sphinx.ext.autodoc`), and another which we use because our docstrings are `NumPy` style (`sphinx.ext.napoleon`).  The `mathjax` extension allows us to render latex into equations, and the `viewcode` extensions will add links to highlighted source code.
+CookieCutter has added a few extensions here which will allow us to pull doc strings from our Python
+modules (`sphinx.ext.autosummary`, `sphinx.ext.autodoc`), and another which we use because our docstrings are `NumPy`
+style (`sphinx.ext.napoleon`). The `mathjax` extension allows us to render latex into equations, and the `viewcode`
+extensions will add links to highlighted source code.
 
-Next, we have added the line `autosummary_generate = True` to allow us to pull auto summaries from our modules and functions.
+Next, we have added the line `autosummary_generate = True` to allow us to pull auto summaries from our modules and
+functions.
 
 ## Automatically Generating Documentation Using Sphinx-AutoAPI
-Sphinx comes bundled with some extensions which have other directives. You can also download and install many Sphinx extensions from pip or conda.
 
-One common use of Sphinx is to create API documentation (ie, pull the docstrings from your modules) The cookiecutter comes bundled with Sphinx AutoSummary and AutoDoc extensions. However, you may have noticed that these are a bit labor-intensive if all you want to do is pull out the docstrings. If this is the approach you would like to take, you can use a Sphinx extension called `AutoAPI`. AutoAPI will pull documentation for all of your functions at once, rather than you having to build them manually.
+Sphinx comes bundled with some extensions which have other directives. You can also download and install many Sphinx
+extensions from pip or conda.
+
+One common use of Sphinx is to create API documentation (ie, pull the docstrings from your modules) The cookiecutter
+comes bundled with Sphinx AutoSummary and AutoDoc extensions. However, you may have noticed that these are a bit
+labor-intensive if all you want to do is pull out the docstrings. If this is the approach you would like to take, you
+can use a Sphinx extension called `AutoAPI`. AutoAPI will pull documentation for all of your functions at once, rather
+than you having to build them manually.
 
 This is [Spinx-AutoAPI](https://github.com/readthedocs/sphinx-autoapi). To install Sphinx-AutoAPI, use `pip`:
 
@@ -418,17 +491,19 @@ pip install sphinx-autoapi
 ~~~
 {: .language-bash}
 
-To get Sphinx-AutoAPI to work, we will need change some things about the Sphinx configuration, which is specified in the `conf.py`.
+To get Sphinx-AutoAPI to work, we will need change some things about the Sphinx configuration, which is specified in
+the `conf.py`.
 
-There are a few modifications necessary to use Sphinx-AutoAPI.  
- - In `docs/conf.py`, remove `sphinx.ext.autodoc` and `sphinx.ext.autosummary` and add `autoapi.extension` to the
- `extensions` list variable. Then comment out or delete the line: `autosummary_generate = True`.
- - Optional: remove `* :ref:'modindex'` from `docs/index.rst`, since an API Reference tab will show up autmoatically in
- `.. toctree::` after compilation.
+There are a few modifications necessary to use Sphinx-AutoAPI.
 
-Once this is configured, you may now choose the modules and functions you would like Sphinx-AutoAPI to include
-or ignore in its automatic generation of documentation. To do this, in the `docs/conf.py` file, you may now add the
-following lines directly following the declaration of the `extensions` variable:
+- In `docs/conf.py`, remove `sphinx.ext.autodoc` and `sphinx.ext.autosummary` and add `autoapi.extension` to the
+  `extensions` list variable. Then comment out or delete the line: `autosummary_generate = True`.
+- Optional: remove `* :ref:'modindex'` from `docs/index.rst`, since an API Reference tab will show up autmoatically in
+  `.. toctree::` after compilation.
+
+Once this is configured, you may now choose the modules and functions you would like Sphinx-AutoAPI to include or ignore
+in its automatic generation of documentation. To do this, in the `docs/conf.py` file, you may now add the following
+lines directly following the declaration of the `extensions` variable:
 
 ~~~
 autoapi_dirs = ['../molecool']
@@ -483,19 +558,27 @@ napoleon_use_ivar = True
 {: .language-python}
 
 Once compiled, this will generate documentation for all files in the `molecool` source directory, as well as exclude
-generating documentation for the tests and versioneering files in the project. The `index.rst` file will be updated
-to include an `API Reference` page, and the resultant `.html` files can be viewed in the `_build` directory upon 
+generating documentation for the tests and versioneering files in the project. The `index.rst` file will be updated to
+include an `API Reference` page, and the resultant `.html` files can be viewed in the `_build` directory upon
 compilation.
-
 
 ## Hosting your documentation
 
 ### Read The Docs
-We recommend hosing your  documentation on [Read The Docs](https://readthedocs.org/). With this service, you can enable the building of your documentation every time you push to your repository.
 
-Go to the [Read the Docs](https://readthedocs.org/) website. Log in with your GitHub username and hook the repository to read the docs. Push to the repository, or trigger a build on the site. Because of the recent switch from `master` to `main`, you may get an error that your build has failed. In order to fix this, click "Admin" in the menu, then on the side bar click "Advanced Settings". Under "Default branch" choose "main". Trigger a build again after making this change.
+We recommend hosing your documentation on [Read The Docs](https://readthedocs.org/). With this service, you can enable
+the building of your documentation every time you push to your repository.
 
-Unfortunately, your documentation build will fail again. This is because we need our dependencies installed on RTD. There is another file the CookieCutter has added which we must now modify. Add your dependencies (numpy and matplotlib) to `docs/requirements.yaml`. You should also add `sphinx-autoapi` under `pip only installs`. Your `requirements.yaml` will look like this:
+Go to the [Read the Docs](https://readthedocs.org/) website. Log in with your GitHub username and hook the repository to
+read the docs. Push to the repository, or trigger a build on the site. Because of the recent switch from `master`
+to `main`, you may get an error that your build has failed. In order to fix this, click "Admin" in the menu, then on the
+side bar click "Advanced Settings". Under "Default branch" choose "main". Trigger a build again after making this
+change.
+
+Unfortunately, your documentation build will fail again. This is because we need our dependencies installed on RTD.
+There is another file the CookieCutter has added which we must now modify. Add your dependencies (numpy and matplotlib)
+to `docs/requirements.yaml`. You should also add `sphinx-autoapi` under `pip only installs`. Your `requirements.yaml`
+will look like this:
 
 ~~~
 name: docs

--- a/setup.md
+++ b/setup.md
@@ -4,7 +4,9 @@ title: "Setup"
 
 This setup tutorial will walk you through installing the software you will need for this workshop.
 
-For this workshop, you will need to have Python installed. We recommend and assume you will have Python installed using Anaconda, and will be talking about package management using conda and Anaconda (see instructions below). You will also need to download workshop materials, and configure git.
+For this workshop, you will need to have Python installed. We recommend and assume you will have Python installed using
+Anaconda, and will be talking about package management using conda and Anaconda (see instructions below). You will also
+need to download workshop materials, and configure git.
 
 We will cover the following topics. Click on a particular topic to skip to that section.
 
@@ -18,12 +20,14 @@ We will cover the following topics. Click on a particular topic to skip to that 
 
 ## Workshop materials <a name="materials_download"></a>
 
-In this workshop, we will be moving code from a Jupyter notebook into a Python package that we can install and import into other scripts.
+In this workshop, we will be moving code from a Jupyter notebook into a Python package that we can install and import
+into other scripts.
 
 ## Download the starting workshop materials [here](./data/starting_material.zip)
 
 - Create a folder on your desktop called `molssi_best_practices`.
-- The file you download as starting materials will be a `zip` file. You should unzip this file into the folder you have created on your desktop. After downloading and unzipping, verify that you see the following directory structure.
+- The file you download as starting materials will be a `zip` file. You should unzip this file into the folder you have
+  created on your desktop. After downloading and unzipping, verify that you see the following directory structure.
     ~~~
     molssi_best_practices
     └── starting_material  
@@ -43,58 +47,78 @@ In this workshop, we will be moving code from a Jupyter notebook into a Python p
 
 If you already have a Python 3 verison Anaconda or MiniConda installed, you can skip this step.
 
-[Python][python] is a popular language for scientific computing, and great for
-general-purpose programming as well.  We recommend using Python with the conda package manager. 
-You can obtain Python and conda by either installing [Miniconda](https://docs.conda.io/en/latest/miniconda.html) (minimal installer) or [Anaconda](https://www.anaconda.com/products/individual). Anaconda comes bundled with many more python packages than miniconda. Anaconda is more user-friendly. If you are uncomfortable navigating the terminal, or are unsure of which you need, install Anaconda. Anaconda will also come bundled with the text editor Visual Studio Code, so you will not need to install a text editor in the next step.
+[Python][python] is a popular language for scientific computing, and great for general-purpose programming as well. We
+recommend using Python with the conda package manager. You can obtain Python and conda by either
+installing [Miniconda](https://docs.conda.io/en/latest/miniconda.html) (minimal installer)
+or [Anaconda](https://www.anaconda.com/products/individual). Anaconda comes bundled with many more python packages than
+miniconda. Anaconda is more user-friendly. If you are uncomfortable navigating the terminal, or are unsure of which you
+need, install Anaconda. Anaconda will also come bundled with the text editor Visual Studio Code, so you will not need to
+install a text editor in the next step.
 
-The installer for Anaconda can be found on [this page](https://www.anaconda.com/products/individual). Choose the appropriate version for your Operating System.
+The installer for Anaconda can be found on [this page](https://www.anaconda.com/products/individual). Choose the
+appropriate version for your Operating System.
 
 Throughout the rest of this set-up, we will assume that you are using the `conda` package manager.
 
-Please set up your python environment at
-as far in advance as possible.  If you encounter problems with the
-installation procedure, ask your workshop organizers via e-mail for assistance so
-you are ready to go as soon as the workshop begins.
+Please set up your python environment at as far in advance as possible. If you encounter problems with the installation
+procedure, ask your workshop organizers via e-mail for assistance so you are ready to go as soon as the workshop begins.
 
 ## Choosing a text editor <a name="text_editor"></a>
-You will need an editor for Python files for this workshop. If you do not have a prefered text editor, we recommend [Visual Studio Code](https://code.visualstudio.com/). If you installed a recent version of Anaconda, you will have VSCode installed already. You should be able to open it from the Anaconda Navigator window. If you have another prefered text editor, you should use that for the workshop.
+
+You will need an editor for Python files for this workshop. If you do not have a prefered text editor, we
+recommend [Visual Studio Code](https://code.visualstudio.com/). If you installed a recent version of Anaconda, you will
+have VSCode installed already. You should be able to open it from the Anaconda Navigator window. If you have another
+prefered text editor, you should use that for the workshop.
 
 ## Using Anaconda and conda
 
 Use of [Anaconda] with its package manager, `conda`, greatly simplifies package installation and environment management.
 
-`conda` is a general package manager, meaning that it can install dependencies and packages in languages besides Python, unlike `pip` (which is Python's package manager). Both `pip` and `conda` can be used to install packages.
+`conda` is a general package manager, meaning that it can install dependencies and packages in languages besides Python,
+unlike `pip` (which is Python's package manager). Both `pip` and `conda` can be used to install packages.
 
 ### Python environments <a name="python_environment"></a>
-A `conda` environment contains a specific collection of packages you have installed. This means that packages are isolated, and installed only for a specific environment -- you can have several environments each with different installed packages, or different versions of installed packages in different environments.
+
+A `conda` environment contains a specific collection of packages you have installed. This means that packages are
+isolated, and installed only for a specific environment -- you can have several environments each with different
+installed packages, or different versions of installed packages in different environments.
 
 It's considered a best practice to create a new Python environment for each project you work on.
 
-This section uses the command line interface (CLI) to create an environment using `conda`. If you are on Mac or Linux, you will type these commands into your terminal.  If you are on Windows, you should use the Anaconda Prompt. 
+This section uses the command line interface (CLI) to create an environment using `conda`. If you are on Mac or Linux,
+you will type these commands into your terminal. If you are on Windows, you should use the Anaconda Prompt.
 
 To create an environment for this project using `conda`,
 
 ~~~
 $ conda create --name molssi_best_practices python=3.7
 ~~~
+
 {: .language-bash}
 
-For other projects, you should replace `molssi_best_practices` with a descriptive name for your project. `conda` also allows you to specify the python version to use with the environment. Here, `python=3.7` specifies that we want to use Python 3.7 in this environment. Executing this command will list the environment location and a list of Python packages to be installed. Choose `y(es)` when prompted.
+For other projects, you should replace `molssi_best_practices` with a descriptive name for your project. `conda` also
+allows you to specify the python version to use with the environment. Here, `python=3.7` specifies that we want to use
+Python 3.7 in this environment. Executing this command will list the environment location and a list of Python packages
+to be installed. Choose `y(es)` when prompted.
 
 Activate the environment using the command
 
 ~~~
 $ conda activate molssi_best_practices
 ~~~
+
 {: .language-bash}
 
-Once you've activated an environment, the name of the environment will be in parenthesis at the front of your command line prompt.
+Once you've activated an environment, the name of the environment will be in parenthesis at the front of your command
+line prompt.
 
-If you wanted to create an environment for testing your code in Python 3.5, for example, you could use the command (Do not execute this, it's just an example.)
+If you wanted to create an environment for testing your code in Python 3.5, for example, you could use the command (Do
+not execute this, it's just an example.)
 
 ~~~
 $ conda create --name molssi_35 python=3.5
 ~~~
+
 {: .language-bash}
 
 When this environment is activated, Python 3.5 will be used instead of Python 3.7.
@@ -104,6 +128,7 @@ To see a list of all your environments
 ~~~
 $ conda info --envs
 ~~~
+
 {: .language-bash}
 
 To deactivate an environment, type
@@ -111,14 +136,18 @@ To deactivate an environment, type
 ~~~
 $ conda deactivate
 ~~~
+
 {: .language-bash}
 
 ### Package installation using conda
-Using `conda`, we can install packages to our environments. **Note**: Make sure you have activated the environment where you want to install packages.
+
+Using `conda`, we can install packages to our environments. **Note**: Make sure you have activated the environment where
+you want to install packages.
 
 ~~~
 $ conda activate molssi_best_practices
 ~~~
+
 {: .language-bash}
 
 To list all the Python packages installed in an environment, first activate it, then type
@@ -126,6 +155,7 @@ To list all the Python packages installed in an environment, first activate it, 
 ~~~
 $ conda list
 ~~~
+
 {: .language-bash}
 
 Packages can be installed using the `conda install package_name` command. For example, to install NumPy,
@@ -133,6 +163,7 @@ Packages can be installed using the `conda install package_name` command. For ex
 ~~~
 $ conda install numpy
 ~~~
+
 {: .language-bash}
 
 Further, the desired version of NumPy can be specified:
@@ -140,9 +171,11 @@ Further, the desired version of NumPy can be specified:
 ~~~
 $ conda install numpy=1.15
 ~~~
+
 {: .language-bash}
 
 For this workshop, you will need to install the following packages into your environment
+
 - NumPy
 - Matplotlib
 - jupyter notebook
@@ -153,18 +186,20 @@ You can install then using the commands
 $ conda install numpy matplotlib
 $ conda install -c conda-forge notebook
 ~~~
-{: .language-bash}
 
+{: .language-bash}
 
 ## CookieCutter Installation <a name="cookiecutter"></a>
 
-For this workshop, we will create the structure of our Python package using the [CMS CookieCutter]. Please have this package installed **in your `molssi_best_practices` environment**.
+For this workshop, we will create the structure of our Python package using the [CMS CookieCutter]. Please have this
+package installed **in your `molssi_best_practices` environment**.
 
 First, switch to your environment for this workshop if you are not in it.
 
 ~~~
 $ conda activate molssi_best_practices
 ~~~
+
 {: .language-bash}
 
 Install the general cookiecutter with the following commands.
@@ -173,53 +208,58 @@ Install the general cookiecutter with the following commands.
 $ conda config --add channels conda-forge
 $ conda install cookiecutter
 ~~~
+
 {: .language-bash}
 
 ## Installing and configuring git <a name="git_configuration"></a>
 
 ### Installation
+
 Install git. You can install using conda
 
 ~~~
 $ conda install git
 ~~~
+
 {: .language-bash}
 
 ### Configuring Git
 
 The first time you use Git on a particular computer, you need to configure some things.
 
-First, you should set your identity.
-One of the most important things that version control like Git does is to keep track of who changes what.
-This helps repository maintainers coordinate the efforts of all the people who contribute to the project.
-Most importantly, it makes it easier to figure out who to blame when something goes wrong.
-You can provide git your name and contact information with the following commands:
+First, you should set your identity. One of the most important things that version control like Git does is to keep
+track of who changes what. This helps repository maintainers coordinate the efforts of all the people who contribute to
+the project. Most importantly, it makes it easier to figure out who to blame when something goes wrong. You can provide
+git your name and contact information with the following commands:
 
 ~~~
 $ git config --global user.name "<Firstname> <Lastname>"
 $ git config --global user.email "<email address>"
 ~~~
+
 {: .bash}
 
-Next, you might want to change the Git text editor.
-As we will see later, certain Git commands will open text files.
-When this happens, Git will use your environment's default text editor, which might not be the editor you are most comfortable using.
-Using configuration commands, you can tell Git to use your favorite editor.
+Next, you might want to change the Git text editor. As we will see later, certain Git commands will open text files.
+When this happens, Git will use your environment's default text editor, which might not be the editor you are most
+comfortable using. Using configuration commands, you can tell Git to use your favorite editor.
 
 A popular chose is Vim. To use Vim, do
 
 ~~~
 $ git config --global core.editor "vim"
 ~~~
+
 {: .bash}
 
-A more complete list of possible editors is available [here](http://swcarpentry.github.io/git-novice/02-setup/index.html).
+A more complete list of possible editors is
+available [here](http://swcarpentry.github.io/git-novice/02-setup/index.html).
 
 To use VSCode as your core editor, do
 
 ~~~
 $ git config --global core.editor "code --wait"
 ~~~
+
 {: .language-bash}
 
 You can check the configuration commands that you have set using:
@@ -227,17 +267,27 @@ You can check the configuration commands that you have set using:
 ~~~
 $ git config --list
 ~~~
+
 {: .bash}
 
 ## Create GitHub Account <a name="github_account"></a>
-Create an account on [github.com] if you do not have one already. Remember the user name and password. If you are making a GitHub account, please remember that your username should be *recognizable* and *professional*.
+
+Create an account on [github.com] if you do not have one already. Remember the user name and password. If you are making
+a GitHub account, please remember that your username should be *recognizable* and *professional*.
 
 ### Conclusion
-At the end of this set-up, you should have created a Python environment (`molssi_best_practices`) which has Python 3.7, `numpy`, `matplotlib`, `jupyter`, and `cookiecutter` installed. You should also have downloaded starting material, installed and created an account on GitHub, and configured git.
+
+At the end of this set-up, you should have created a Python environment (`molssi_best_practices`) which has Python
+3.7, `numpy`, `matplotlib`, `jupyter`, and `cookiecutter` installed. You should also have downloaded starting material,
+installed and created an account on GitHub, and configured git.
 
 
 [anaconda]: https://www.anaconda.com
+
 [https://www.anaconda.com/download]: https://www.anaconda.com/download
+
 [python]: https://python.org
+
 [github.com]: https://github.coms
+
 [CMS CookieCutter]: https://github.com/MolSSI/cookiecutter-cms


### PR DESCRIPTION
Conservatively add a bunch of line breaks to try to reduce diff noise and merge conflicts in future changes.

Hopefully, I didn't break any Jekyll directives.

I figured it would be slightly easier to handle addition of line breaks in future changes than to expect people to diligently remove them, but at least most of the paragraphs are broken into more lines to try to isolate single-word edits a bit more.

If it makes more sense to break lines at 80 characters, I can do that. If we want to break at stricter boundaries, like sentences and fragments, it probably isn't worth the effort of doing that in a single change, but rather something we should just start expecting to see accompanying other changes.
