### PR TITLE
GitHub auth

### DIFF
--- a/_episodes/03-github.md
+++ b/_episodes/03-github.md
@@ -12,6 +12,16 @@ keypoints:
 - "You can use GitHub to store your projects so you can work on them from multiple computers."
 
 ---
+## Securely accessing GitHub
+During the setup for this workshop, we generated an SSH key and added it to our GitHub account.
+The SSH key will allow us to authenticate our identity to GitHub, allowing us access to our remote repositories.
+For the purposes of this workshop, an SSH key is a good way to quickly and conveniently get set up using GitHub.
+If you continue further development using GitHub after this workshop, you may want to consider alternatives.
+
+GitHub has added a feature called Personal Access Tokens (PATs) that allow for more fine grained security control over your access.
+Instead of one key that has all the permissions on your account, you can define multiple tokens that have a different set of permissions.
+GitHub has good documentation for [generating and using a PAT](https://docs.github.com/en/github/authenticating-to-github/keeping-your-account-and-data-secure/creating-a-personal-access-token).
+
 
 ## Putting your repository on GitHub.
 Now, let's put this project on GitHub so that we can share it with others. In your browser, navigate to `github.com`. Log in to you account if you are not already logged in. On the left side of the page, click the green button that says `New` to create a new repository. Give the repository the name `molecool`.

--- a/setup.md
+++ b/setup.md
@@ -211,6 +211,12 @@ $ git config --global user.name "YOUR NAME"
 $ git config --global user.email "YOUR_EMAIL"
 ~~~
 {: .bash}
+You should next set the default branch name you will work on. Branches will be explained in detail later. This configuration setting makes the default branch name match the default branch name on GitHub
+
+~~~
+git config --global init.defaultBranch main
+~~~
+{: .bash}
 
 Next, you might want to change the Git text editor.
 As we will see later, certain Git commands will open text files.

--- a/setup.md
+++ b/setup.md
@@ -235,6 +235,7 @@ Create an account on [github.com] if you do not have one already. Remember the u
 The next step is to verify your email address through Github.
 If you do not verify your email address, you will not be able to perform many of the actions covered in this workshop.
 
+## Setting up a Personal Access Token (PAT) for Github
 To utilize github from the command line, you will need to generate a Personal Access Token (PAT).
 To create a PAT:
 1. Click the profile photo option in the upper right hand corner of any page, then click `Settings`.
@@ -259,6 +260,12 @@ git config --global credential.helper cache
 ```
 which will cache your token in memory for 15 minutes after it has been entered.
 
+If you would like to modify the length of time a token is cached, you can use the command:
+```
+git config --global credential.helper 'cache --timeout=3600'
+```
+where the value after timeout is the length of time to cache in seconds (1 hour in this example).
+
 For Mac OS, you need a separate tool, `osxkeychain` to cache your token.
 You can check if you have it installed already by running
 ```
@@ -269,14 +276,16 @@ Then run
 ```
 git config --global credential.helper osxkeychain
 ```
-to setup caching with a default time of 15 minutes.
+to setup caching for your operating system.
+Your PAT will be stored locally on your machine and encrypted by the operating system.
 
-If you would like to modify the length of time a token is cached, you can use the command:
+If you would like to store the PAT locally and have git automatically reference it on Linux/WSL, you can specify that git should store your PAT.
+This can be done through the command
 ```
-git config --global credential.helper 'cache --timeout=3600'
+git config --global credential.helper 'store --file ~/.my-credentials'
 ```
-where the value after timeout is the length of time to cache in seconds (1 hour in this example).
-
+where `~/.my-credentials` is a filepath to a file git should store your PAT in.
+Note that this is stored as plain text on your machine.
 
 ### Conclusion
 At the end of this set-up, you should have created a Python environment (`molssi_best_practices`) which has Python 3.7, `numpy`, `matplotlib`, `jupyter`, and `cookiecutter` installed. You should also have downloaded starting material, installed and created an account on GitHub, and configured git.

--- a/setup.md
+++ b/setup.md
@@ -241,11 +241,41 @@ To create a PAT:
 2. On the settings page, look on the left sidebar and click `Developer settings`.
 3. In the new left sidebar, click `Personal access tokens`.
 4. Click the `Generate new token` button to bring up the options for your token.
-You can create different authentication tokens for different actions on Github.
-For the purposes of this workshop, you should only need to select the `repo` option at the top.
+You can create different access tokens for different actions on Github.
+For the purposes of this workshop, you should only need to select the `repo` and `workflow` options, the two at the top.
+You can return to the settings page at a later time to add or remove scopes from your token.
 5. Once you have checked this box, click the `Generate token` button at the bottom of the set of options.
-Make sure to copy the authentication token as Github will not let you see it again once you have navigated from the page.
+Make sure to copy the access token as Github will not let you see it again once you have navigated from the page.
 This token will be used in place of your password when you utilize the command line to access Github repositories.
+
+By default, you will be required to enter your PAT every time you want to push to a github repository.
+This can become tedius if you are making multiple pushes over a short period.
+Git has options to cache your PAT in local memory for a specified time period, meaning you only have to re-enter your password if enough time has passed.
+If you would like to setup caching you have to take different steps depending on your operating system.
+
+For Linux and Windows WSL, you simply run
+```
+git config --global credential.helper cache
+```
+which will cache your token in memory for 15 minutes after it has been entered.
+
+For Mac OS, you need a separate tool, `osxkeychain` to cache your token.
+You can check if you have it installed already by running
+```
+git credential-osxkeychain
+```
+If you do not have it installed, you should be prompted to install it by the console.
+Then run
+```
+git config --global credential.helper osxkeychain
+```
+to setup caching with a default time of 15 minutes.
+
+If you would like to modify the length of time a token is cached, you can use the command:
+```
+git config --global credential.helper 'cache --timeout=3600'
+```
+where the value after timeout is the length of time to cache in seconds (1 hour in this example).
 
 
 ### Conclusion

--- a/setup.md
+++ b/setup.md
@@ -56,6 +56,14 @@ as far in advance as possible.  If you encounter problems with the
 installation procedure, ask your workshop organizers via e-mail for assistance so
 you are ready to go as soon as the workshop begins.
 
+> ## Windows Subsytem for Linux (WSL)
+> 
+> If you plan to continue developing in the future and you utilize the Windows Operating system, you may want to consider installing the WSL.
+> The WSL will allow you to run a Linux based terminal from your Windows machine, which can aid in the development and running of code.
+> The WSL can connect to VS code for easy development.
+> You can find instructions to install the WSL on the [Windows Documentation](https://docs.microsoft.com/en-us/windows/wsl/install-win10).
+{: .callout}
+
 ## Choosing a text editor <a name="text_editor"></a>
 You will need an editor for Python files for this workshop. If you do not have a prefered text editor, we recommend [Visual Studio Code](https://code.visualstudio.com/). If you installed a recent version of Anaconda, you will have VSCode installed already. You should be able to open it from the Anaconda Navigator window. If you have another prefered text editor, you should use that for the workshop.
 

--- a/setup.md
+++ b/setup.md
@@ -147,7 +147,10 @@ For this workshop, you will need to install the following packages into your env
 - Matplotlib
 - jupyter notebook
 
-You can install then using the commands
+Packages available to Conda are stored within `channels`.
+Some packages are not stored in the default Conda channel, so we need to specify where Conda can find the package with `-c` followed by a channel name in our install command.
+The `NumPy` and `Matplotlib` packages are both stored within the default Conda channel, so we do not need to include a `-c`.
+The `jupyter notebook` package is in the `conda-forge` channel, so we include the syntax `-c conda-forge` in our install command.
 
 ~~~
 $ conda install numpy matplotlib
@@ -196,8 +199,8 @@ Most importantly, it makes it easier to figure out who to blame when something g
 You can provide git your name and contact information with the following commands:
 
 ~~~
-$ git config --global user.name "<Firstname> <Lastname>"
-$ git config --global user.email "<email address>"
+$ git config --global user.name "YOUR NAME"
+$ git config --global user.email "YOUR_EMAIL"
 ~~~
 {: .bash}
 
@@ -235,7 +238,7 @@ Create an account on [github.com] if you do not have one already. Remember the u
 The next step is to verify your email address through Github.
 If you do not verify your email address, you will not be able to perform many of the actions covered in this workshop.
 
-## Setting up a Personal Access Token (PAT) for Github
+## Accessing GitHub through the Command Line
 To utilize github from the command line, you will need to
 [provide GitHub with an SSH public key](https://docs.github.com/en/github/authenticating-to-github/connecting-to-github-with-ssh)
 or generate a GitHub Personal Access Token (PAT).

--- a/setup.md
+++ b/setup.md
@@ -253,60 +253,12 @@ The next step is to verify your email address through Github.
 If you do not verify your email address, you will not be able to perform many of the actions covered in this workshop.
 
 ## Accessing GitHub through the Command Line
-To utilize github from the command line, you will need to
-[provide GitHub with an SSH public key](https://docs.github.com/en/github/authenticating-to-github/connecting-to-github-with-ssh)
-or generate a GitHub Personal Access Token (PAT).
+To utilize GitHub from the command line, you will need to
+[provide GitHub with an SSH public key](https://docs.github.com/en/github/authenticating-to-github/connecting-to-github-with-ssh).
+An SSH key is a means to authenticate remote servers.
+With an SSH key, you will be able to access your GitHub repositories through the command line without the need to enter a username and password.
+The linked documentation provides information about SSH keys, how to find out if you already have an SSH key, and how to generate and add one to your GitHub account.
 
-
-To create a PAT:
-1. Click the profile photo option in the upper right hand corner of any page, then click `Settings`.
-2. On the settings page, look on the left sidebar and click `Developer settings`.
-3. In the new left sidebar, click `Personal access tokens`.
-4. Click the `Generate new token` button to bring up the options for your token.
-You can create different access tokens for different actions on Github.
-For the purposes of this workshop, you should only need to select the `repo` and `workflow` options, the two at the top.
-You can return to the settings page at a later time to add or remove scopes from your token.
-5. Once you have checked this box, click the `Generate token` button at the bottom of the set of options.
-Make sure to copy the access token as Github will not let you see it again once you have navigated from the page.
-This token will be used in place of your password when you utilize the command line to access Github repositories.
-
-By default, you will be required to enter your PAT every time you want to push to a github repository.
-This can become tedious if you are making multiple pushes over a short period.
-Git has options to cache your PAT in local memory for a specified time period, meaning you only have to re-enter your password if enough time has passed.
-If you would like to setup caching you have to take different steps depending on your operating system.
-
-For Linux and Windows WSL, you simply run
-```
-git config --global credential.helper cache
-```
-which will cache your token in memory for 15 minutes after it has been entered.
-
-If you would like to modify the length of time a token is cached, you can use the command:
-```
-git config --global credential.helper 'cache --timeout=3600'
-```
-where the value after timeout is the length of time to cache in seconds (1 hour in this example).
-
-For Mac OS, you need a separate tool, `osxkeychain` to cache your token.
-You can check if you have it installed already by running
-```
-git credential-osxkeychain
-```
-If you do not have it installed, you should be prompted to install it by the console.
-Then run
-```
-git config --global credential.helper osxkeychain
-```
-to set up caching for your operating system.
-Your PAT will be stored locally on your machine and encrypted by the operating system.
-
-If you would like to store the PAT locally and have git automatically reference it on Linux/WSL, you can specify that git should store your PAT.
-This can be done through the command
-```
-git config --global credential.helper 'store --file ~/.my-credentials'
-```
-where `~/.my-credentials` is a filepath to a file git should store your PAT in.
-Note that this is stored as plain text on your machine.
 
 ### Conclusion
 At the end of this set-up, you should have created a Python environment (`molssi_best_practices`) which has Python 3.7, `numpy`, `matplotlib`, `jupyter`, and `cookiecutter` installed. You should also have downloaded starting material, installed and created an account on GitHub, and configured git.

--- a/setup.md
+++ b/setup.md
@@ -265,7 +265,7 @@ Make sure to copy the access token as Github will not let you see it again once 
 This token will be used in place of your password when you utilize the command line to access Github repositories.
 
 By default, you will be required to enter your PAT every time you want to push to a github repository.
-This can become tedius if you are making multiple pushes over a short period.
+This can become tedious if you are making multiple pushes over a short period.
 Git has options to cache your PAT in local memory for a specified time period, meaning you only have to re-enter your password if enough time has passed.
 If you would like to setup caching you have to take different steps depending on your operating system.
 

--- a/setup.md
+++ b/setup.md
@@ -232,6 +232,22 @@ $ git config --list
 ## Create GitHub Account <a name="github_account"></a>
 Create an account on [github.com] if you do not have one already. Remember the user name and password. If you are making a GitHub account, please remember that your username should be *recognizable* and *professional*.
 
+The next step is to verify your email address through Github.
+If you do not verify your email address, you will not be able to perform many of the actions covered in this workshop.
+
+To utilize github from the command line, you will need to generate a Personal Authentication Token (PAT).
+To create a PAT:
+1. Click the profile photo option in the upper right hand corner of any page, then click `Settings`.
+2. On the settings page, look on the left sidebar and click `Developer settings`.
+3. In the new left sidebar, click `Personal access tokens`.
+4. Click the `Generate new token` button to bring up the options for your token.
+You can create different authentication tokens for different actions on Github.
+For the purposes of this workshop, you should only need to select the `repo` option at the top.
+5. Once you have checked this box, click the `Generate token` button at the bottom of the set of options.
+Make sure to copy the authentication token as Github will not let you see it again once you have navigated from the page.
+This token will be used in place of your password when you utilize the command line to access Github repositories.
+
+
 ### Conclusion
 At the end of this set-up, you should have created a Python environment (`molssi_best_practices`) which has Python 3.7, `numpy`, `matplotlib`, `jupyter`, and `cookiecutter` installed. You should also have downloaded starting material, installed and created an account on GitHub, and configured git.
 

--- a/setup.md
+++ b/setup.md
@@ -83,7 +83,7 @@ This section uses the command line interface (CLI) to create an environment usin
 To create an environment for this project using `conda`,
 
 ~~~
-$ conda create --name molssi_best_practices python=3.7
+$ conda create --name molssi_best_practices python=3.9
 ~~~
 {: .language-bash}
 
@@ -192,7 +192,7 @@ $ conda install cookiecutter
 Install git. You can install using conda
 
 ~~~
-$ conda install git
+$ conda install -c conda-forge git
 ~~~
 {: .language-bash}
 

--- a/setup.md
+++ b/setup.md
@@ -235,7 +235,7 @@ Create an account on [github.com] if you do not have one already. Remember the u
 The next step is to verify your email address through Github.
 If you do not verify your email address, you will not be able to perform many of the actions covered in this workshop.
 
-To utilize github from the command line, you will need to generate a Personal Authentication Token (PAT).
+To utilize github from the command line, you will need to generate a Personal Access Token (PAT).
 To create a PAT:
 1. Click the profile photo option in the upper right hand corner of any page, then click `Settings`.
 2. On the settings page, look on the left sidebar and click `Developer settings`.

--- a/setup.md
+++ b/setup.md
@@ -291,7 +291,7 @@ Then run
 ```
 git config --global credential.helper osxkeychain
 ```
-to setup caching for your operating system.
+to set up caching for your operating system.
 Your PAT will be stored locally on your machine and encrypted by the operating system.
 
 If you would like to store the PAT locally and have git automatically reference it on Linux/WSL, you can specify that git should store your PAT.

--- a/setup.md
+++ b/setup.md
@@ -236,7 +236,11 @@ The next step is to verify your email address through Github.
 If you do not verify your email address, you will not be able to perform many of the actions covered in this workshop.
 
 ## Setting up a Personal Access Token (PAT) for Github
-To utilize github from the command line, you will need to generate a Personal Access Token (PAT).
+To utilize github from the command line, you will need to
+[provide GitHub with an SSH public key](https://docs.github.com/en/github/authenticating-to-github/connecting-to-github-with-ssh)
+or generate a GitHub Personal Access Token (PAT).
+
+
 To create a PAT:
 1. Click the profile photo option in the upper right hand corner of any page, then click `Settings`.
 2. On the settings page, look on the left sidebar and click `Developer settings`.

--- a/setup.md
+++ b/setup.md
@@ -257,7 +257,8 @@ To utilize GitHub from the command line, you will need to
 [provide GitHub with an SSH public key](https://docs.github.com/en/github/authenticating-to-github/connecting-to-github-with-ssh).
 An SSH key is a means to authenticate remote servers.
 With an SSH key, you will be able to access your GitHub repositories through the command line without the need to enter a username and password.
-The linked documentation provides information about SSH keys, how to find out if you already have an SSH key, and how to generate and add one to your GitHub account.
+The linked documentation provides information about SSH keys, how to find out if you already have an SSH key, and how to generate and add one to your GitHub account. 
+You should click the link and follow the instructions to add an SSH key to your GitHub account.
 
 
 ### Conclusion


### PR DESCRIPTION
This simply adds the instructions to create a PAT to be used in place of the password.

With just these instructions, users have to type in/copy paste their PAT in place of their password every time. Do we want to cover caching so that the PAT only needs to be entered after a time period has expired or permanently storing the PAT for gits use?