### PR TITLE
Fix open pdb function in 04 Function Styles

### DIFF
--- a/_episodes/04-function-style.md
+++ b/_episodes/04-function-style.md
@@ -340,10 +340,10 @@ $ git push origin main
 >> ~~~
 >> def calculate_distance(rA, rB):
 >>
->>    dist_vec = (rA - rB)
->>    distance = np.linalg.norm(dist_vec)
+>>     dist_vec = (rA - rB)
+>>     distance = np.linalg.norm(dist_vec)
 >>
->>    return distance
+>>     return distance
 >> ~~~
 >> {: .language-python}
 > {: .solution}

--- a/_episodes/04-function-style.md
+++ b/_episodes/04-function-style.md
@@ -305,7 +305,7 @@ def open_pdb(file_location):
         if 'ATOM' in line[0:6] or 'HETATM' in line[0:6]:
             symbols.append(line[76:79].strip())
             atom_coords = [float(x) for x in line[30:55].split()]
-            coordinates.append(coords)
+            coordinates.append(atom_coords)
 
     coords = np.array(coordinates)
     symbols = np.array(symbols)


### PR DESCRIPTION
At the end of this lesson testing, I found that flake8 gives more messages than suppose to be:
```
molecool_test/functions.py:8:1: F401 'os' imported but unused
molecool_test/functions.py:12:1: F401 'mpl_toolkits.mplot3d.Axes3D' imported but unused
molecool_test/functions.py:121:13: F841 local variable 'atom_coords' is assigned to but never used
molecool_test/functions.py:122:32: F821 undefined name 'coords'
molecool_test/functions.py:158:120: E501 line too long (145 > 119 characters)
```
As it turns out, there is a little bit of inconsistency inside open_pdb function. After I fix the variable name, flake8 gives the following message:
```
molecool_test/functions.py:8:1: F401 'os' imported but unused
molecool_test/functions.py:12:1: F401 'mpl_toolkits.mplot3d.Axes3D' imported but unused
molecool_test/functions.py:158:120: E501 line too long (145 > 119 characters)
```
Notice that we haven't take into account E501 in the lesson, which is caused by the long line inside the following code:
```python
def write_xyz(file_location, symbols, coordinates):
    
    # Write an xyz file given a file location, symbols, and coordinates.
    num_atoms = len(symbols)
    
    if num_atoms != len(coordinates):
        raise ValueError(f"write_xyz : the number of symbols ({num_atoms}) and number of coordinates ({len(coordinates)}) must be the same to write xyz file!")
    
    with open(file_location, 'w+') as f:
        f.write('{}\n'.format(num_atoms))
        f.write('XYZ file\n')
        
        for i in range(num_atoms):
            f.write('{}\t{}\t{}\t{}\n'.format(symbols[i], 
                                              coordinates[i,0], coordinates[i,1], coordinates[i,2]))

```
which will probably need to be addressed later.