### PR TITLE
fix open_pdb docstring

### DIFF
--- a/_episodes/05-package-structure.md
+++ b/_episodes/05-package-structure.md
@@ -364,24 +364,23 @@ Functions for manipulating pdb files.
 """
 
 def open_pdb(file_location):
-    """Calculate the distance between two points.
+    """Open and read coordinates and atom symbols from a pdb file.
+
+    The pdb file must specify the atom elements in the last column, and follow
+    the conventions outlined in the PDB format specification.
 
     Parameters
     ----------
-    rA, rB : np.ndarray
-        The coordinates of each point.
+    file_location : str
+        The location of the pdb file to read in.
 
     Returns
     -------
-    distance : float
-        The distance between the two points.
+    coords : np.ndarray
+        The coordinates of the pdb file.
+    symbols : list
+        The atomic symbols of the pdb file.
 
-    Examples
-    --------
-    >>> r1 = np.array([0, 0, 0])
-    >>> r2 = np.array([0, 0.1, 0])
-    >>> calculate_distance(r1, r2)
-    0.1
     """
 
     with open(file_location) as f:


### PR DESCRIPTION
When I'm doing docstring test using `pytest -v --doctest-modules molecool` it appears that my `open_pdb` function carry the same docstring as `calculate_distance` function. After I'm doing some backtracking, it starts from lesson 05-package-structure. I was copy and pasting the wrong docstring, my bad.