### PR TITLE
Code consistencies and add more details on 08-CI

### DIFF
--- a/_episodes/08-CI.md
+++ b/_episodes/08-CI.md
@@ -14,7 +14,7 @@ keypoints:
 - "Continuous integration automates development steps, such as testing, coverage, and packaging."
 - "Continuous integration also allows you to test your code on a variety of operative systems and platforms."
 - "The CookieCutter includes (almost) ready-to-use configuration files for GitHub Actions."
-- "You can find GitHub Action steps and other services in GitHub Marketplace"
+- "You can find GitHub Actions steps and other services in GitHub Marketplace"
 ---
 
 > ## Prerequisites
@@ -210,6 +210,8 @@ Open `devtools/conda-envs/test_env.yaml` in your text editor.
 ~~~
 name: test
 channels:
+  - conda-forge
+  - defaults
 dependencies:
     # Base depends
   - python
@@ -226,7 +228,7 @@ dependencies:
 ~~~
 {: .language-yaml }
 
-This is a yaml file just like our GitHub Action file (remember we said YAML is commonly used for configuration files).
+This is a yaml file just like our GitHub Actions file (remember we said YAML is commonly used for configuration files).
 This is a file which can be used to create a conda environment with specified packages.
 For this workshop, we created our environment by typing the command into the terminal.
 This could be inconvenient or impossible to reproduce if we have a lot of dependencies, so conda allows us to specify environments using a yaml file which can be passed on or reused.
@@ -270,15 +272,31 @@ After our package is installed, we run the test:
 
 ## Getting our CI to work
 
-Unfortunately, our CI runs failed.
-To know more about why this was the case, we have to read the GitHub Action log files.
-Click on one of the failing entries.
+Unfortunately, our CI runs failed, which can be seen from the red cross that appear after the last commit message on your main GitHub repository page.
+To know more about why this was the case, we have to read the GitHub Actions log files.
+Click on the red cross then click the Details link from one of the failing entries that marked with red cross.
 The new page you will be redirected to has details about the job at the top and then the contents of the log file underneath.
 Look for red lines that indicate errors in your build.
 
+~~~
+==================================== ERRORS ====================================
+__________ ERROR collecting molecool/tests/test_molecool.py __________
+ImportError while importing test module '/home/runner/work/molecool/molecool/molecool/tests/test_molecool.py'.
+Hint: make sure your test modules/packages have valid Python names.
+Traceback:
+/usr/share/miniconda/envs/test/lib/python3.9/importlib/__init__.py:127: in import_module
+    return _bootstrap._gcd_import(name[level:], package, level)
+molecool/__init__.py:8: in <module>
+    from .functions import *
+molecool/functions.py:9: in <module>
+    import numpy as np
+E   ModuleNotFoundError: No module named 'numpy'
+~~~
+{: .error }
+
 Our tests failed because `numpy` could not be imported.
 When we set up the dependencies, we did not explicitly write either `numpy` or `matplotlib`.
-As such, when GitHub Action creates and configures the machines where our CI runs, these packages are never installed.
+As such, when GitHub Actions creates and configures the machines where our CI runs, these packages are never installed.
 We need to add them to the `devtools/conda-envs/test_env.yaml` file.
 
 > ## Exercise
@@ -290,12 +308,14 @@ We need to add them to the `devtools/conda-envs/test_env.yaml` file.
 >> ~~~
 >> name: test
 >> channels:
+>>  - conda-forge
+>>  - defaults
 >> dependencies:
 >>    # Base depends
 >>  - python
 >>  - pip
 >>
->>  # Package dependencies
+>>    # Package dependencies
 >>  - numpy
 >>  - matplotlib
 >>
@@ -313,9 +333,9 @@ We need to add them to the `devtools/conda-envs/test_env.yaml` file.
 {: .challenge}
 
 After these edits, commit and push to the repository.
-GitHub will now detect a new commit and will start a new build automatically.
+GitHub Actions will now detect a new commit and will start a new build automatically.
 On your GitHub repository, click the Actions tab to see a new CI build running.
-After a minute or two, you should see green checkmarks next to your build jobs.
+After three to five minutes, you should see green checkmarks next to your build jobs.
 Congratulations! GitHub Actions is now set up and tracking your repository.
 
 
@@ -440,7 +460,7 @@ Back to the Codecov `molecool` report page, the sunburst plot gives a hierarchic
 <center><img src="../fig/08_CI/codecov_screenshot.png"></center>
 <br />
 
-[//]: # TODO: Check if the following feature work in GitHub Action, this paragraph is the legacy from Travis CI
+[//]: # TODO: Check if the following feature work in GitHub Actions, this paragraph is the legacy from Travis CI
 
 Red areas represent code that is poorly covered by our tests.
 On the right, you see the latest commits and can click on each one of them to see how they changed overall coverage of the project.


### PR DESCRIPTION
Add more details on 08-CI, also on line 338 I changed "a minute or two minutes" to "three to five minutes", because that is how long it takes for my GHA to run the whole workflow.

Also notice that I add `conda-forge` and `defaults` on channels inside `CI.yaml` because that is how it was generated from CMS Cookiecutter
