### PR TITLE
Best Practices Documentation update

### DIFF
--- a/_episodes/01-package-setup.md
+++ b/_episodes/01-package-setup.md
@@ -381,7 +381,7 @@ Open Python (type `python` into your terminal window), and type
 
 
 This will give a list of locations python looks for packages when you do an import.
-One of the locations should end with `python3.7/site-packages`.
+One of the locations should end with `python3.11/site-packages`.
 The site packages folder is where all of your installed packages for a particular environment are located.
 
 To do a development mode install, type

--- a/_episodes/01-package-setup.md
+++ b/_episodes/01-package-setup.md
@@ -192,8 +192,6 @@ You should see the following directory structure.
 │   ├── README.md
 │   ├── conda-envs                  <- Conda environments for testing
 │   │   └── test_env.yaml
-│   ├── legacy-miniconda-setup      <- Legacy Travis CI Helper, will likely be removed in later version
-│   │   └── before_install.sh
 │   └── scripts
 │       └── create_conda_env.py     <- OS agnostic Helper script to make conda environments based on simple flags
 ├── docs                            <- Documentation template folder with many settings already filled in

--- a/_episodes/05-package-structure.md
+++ b/_episodes/05-package-structure.md
@@ -53,8 +53,6 @@ please review the [package setup] section of the lessons.
 │   ├── README.md
 │   ├── conda-envs                  <- Conda environments for testing
 │   │   └── test_env.yaml
-│   ├── legacy-miniconda-setup      <- Legacy Travis CI Helper, will likely be removed in later version
-│   │   └── before_install.sh
 │   └── scripts
 │       └── create_conda_env.py     <- OS agnostic Helper script to make conda environments based on simple flags
 ├── docs                            <- Documentation template folder with many settings already filled in

--- a/_episodes/08-testing.md
+++ b/_episodes/08-testing.md
@@ -130,7 +130,7 @@ You should see an output similar to the following.
 
 ```{code-block} output
 ============================= test session starts ==============================
-platform darwin -- Python 3.6.8, pytest-3.6.4, py-1.5.4, pluggy-0.6.0
+platform darwin -- Python 3.10.12, pytest-7.4.2, pluggy-1.3.0
 rootdir: /Users/jessica/dev/molecool, inifile:
 collected 1 item
 
@@ -163,7 +163,7 @@ There are a number of additional command line arguments to [explore](https://doc
 
 ```{code-block} output
 ============================= test session starts ==============================
-platform darwin -- Python 3.6.8, pytest-3.6.4, py-1.5.4, pluggy-0.6.0 -- /Users/jessica/miniconda3/bin/python
+platform darwin -- Python 3.10.12, pytest-7.4.2, pluggy-1.3.0 -- /Users/jessica/miniconda3/bin/python
 cachedir: .pytest_cache
 rootdir: /Users/jessica/dev/molecool, inifile:
 collected 1 item
@@ -231,7 +231,7 @@ You should now see an output similar to the following
 
 ```{code-block} output
 ============================================================ test session starts ============================================================
-platform darwin -- Python 3.7.3, pytest-5.2.1, py-1.8.0, pluggy-0.13.0
+platform darwin -- Python 3.10.12, pytest-7.4.2, pluggy-1.3.0
 rootdir: /Users/jessica/lessons/molecool
 collected 2 items
 
@@ -264,7 +264,7 @@ pytest -v
 
 ```{code-block} output
 ============================================================ test session starts ============================================================
-platform darwin -- Python 3.7.3, pytest-5.2.1, py-1.8.0, pluggy-0.13.0
+platform darwin -- Python 3.10.12, pytest-7.4.2, pluggy-1.3.0
 rootdir: /Users/jessica/lessons/molecool
 collected 2 items
 
@@ -1040,7 +1040,7 @@ pytest -v -k "test_calculate_angle_many"
 
 ```{code-block} output
 ============================================================= test session starts =============================================================
-platform darwin -- Python 3.7.3, pytest-5.2.1, py-1.8.0, pluggy-0.13.0 -- /Users/jessica/miniconda3/envs/molecool/bin/python
+platform darwin -- Python 3.10.12, pytest-7.4.2, pluggy-1.3.0 -- /Users/jessica/miniconda3/envs/molecool/bin/python
 cachedir: .pytest_cache
 rootdir: /Users/jessica/lessons/molecool
 collected 14 items / 11 deselected / 3 selected                                                                                               
@@ -1109,7 +1109,7 @@ pytest -v --doctest-modules molecool
 
 ```{code-block} output
 =========================================================================== test session starts ===========================================================================
-platform darwin -- Python 3.7.3, pytest-5.2.1, py-1.8.0, pluggy-0.13.0 -- /Users/jessica/miniconda3/envs/molecool/bin/python
+platform darwin -- Python 3.10.12, pytest-7.4.2, pluggy-1.3.0 -- /Users/jessica/miniconda3/envs/molecool/bin/python
 cachedir: .pytest_cache
 rootdir: /Users/jessica/lessons/molecool
 collected 11 items                                                                                                                                                        
@@ -1140,7 +1140,7 @@ Change the expected answer to 0.2 in the docstring and re-run the test to get th
 
 ```{code-block} output
 =========================================================================== test session starts ===========================================================================
-platform darwin -- Python 3.7.3, pytest-5.2.1, py-1.8.0, pluggy-0.13.0 -- /Users/jessica/miniconda3/envs/molecool/bin/python
+platform darwin -- Python 3.10.12, pytest-7.4.2, pluggy-1.3.0 -- /Users/jessica/miniconda3/envs/molecool/bin/python
 cachedir: .pytest_cache
 rootdir: /Users/jessica/lessons/molecool
 collected 11 items                                                                                                                                                        
@@ -1201,7 +1201,7 @@ pytest --cov=molecool
 
 ```{code-block} output
 =========================================================================== test session starts ===========================================================================
-platform darwin -- Python 3.7.3, pytest-5.2.1, py-1.8.0, pluggy-0.13.0
+platform darwin -- Python 3.10.12, pytest-7.4.2, pluggy-1.3.0
 rootdir: /Users/jessica/lessons/molecool
 plugins: cov-2.8.1
 collected 10 items                                                                                                                                                        
@@ -1209,7 +1209,7 @@ collected 10 items
 molecool/tests/test_measure.py ......                                                                                                                               [ 60%]
 molecool/tests/test_molecule.py ....                                                                                                                                [100%]
 
----------- coverage: platform darwin, python 3.7.3-final-0 -----------
+---------- coverage: platform darwin, python 3.10.12-final-0 -----------
 Name                      Stmts   Miss  Cover
 ---------------------------------------------
 molecool/__init__.py          9      0   100%

--- a/_episodes/08-testing.md
+++ b/_episodes/08-testing.md
@@ -130,7 +130,7 @@ You should see an output similar to the following.
 
 ```{code-block} output
 ============================= test session starts ==============================
-platform darwin -- Python 3.10.12, pytest-7.4.2, pluggy-1.3.0
+platform darwin -- Python 3.11.6, pytest-7.4.2, pluggy-1.3.0
 rootdir: /Users/jessica/dev/molecool, inifile:
 collected 1 item
 
@@ -163,7 +163,7 @@ There are a number of additional command line arguments to [explore](https://doc
 
 ```{code-block} output
 ============================= test session starts ==============================
-platform darwin -- Python 3.10.12, pytest-7.4.2, pluggy-1.3.0 -- /Users/jessica/miniconda3/bin/python
+platform darwin -- Python 3.11.6, pytest-7.4.2, pluggy-1.3.0 -- /Users/jessica/miniconda3/bin/python
 cachedir: .pytest_cache
 rootdir: /Users/jessica/dev/molecool, inifile:
 collected 1 item
@@ -231,7 +231,7 @@ You should now see an output similar to the following
 
 ```{code-block} output
 ============================================================ test session starts ============================================================
-platform darwin -- Python 3.10.12, pytest-7.4.2, pluggy-1.3.0
+platform darwin -- Python 3.11.6, pytest-7.4.2, pluggy-1.3.0
 rootdir: /Users/jessica/lessons/molecool
 collected 2 items
 
@@ -264,7 +264,7 @@ pytest -v
 
 ```{code-block} output
 ============================================================ test session starts ============================================================
-platform darwin -- Python 3.10.12, pytest-7.4.2, pluggy-1.3.0
+platform darwin -- Python 3.11.6, pytest-7.4.2, pluggy-1.3.0
 rootdir: /Users/jessica/lessons/molecool
 collected 2 items
 
@@ -1040,7 +1040,7 @@ pytest -v -k "test_calculate_angle_many"
 
 ```{code-block} output
 ============================================================= test session starts =============================================================
-platform darwin -- Python 3.10.12, pytest-7.4.2, pluggy-1.3.0 -- /Users/jessica/miniconda3/envs/molecool/bin/python
+platform darwin -- Python 3.11.6, pytest-7.4.2, pluggy-1.3.0 -- /Users/jessica/miniconda3/envs/molecool/bin/python
 cachedir: .pytest_cache
 rootdir: /Users/jessica/lessons/molecool
 collected 14 items / 11 deselected / 3 selected                                                                                               
@@ -1109,7 +1109,7 @@ pytest -v --doctest-modules molecool
 
 ```{code-block} output
 =========================================================================== test session starts ===========================================================================
-platform darwin -- Python 3.10.12, pytest-7.4.2, pluggy-1.3.0 -- /Users/jessica/miniconda3/envs/molecool/bin/python
+platform darwin -- Python 3.11.6, pytest-7.4.2, pluggy-1.3.0 -- /Users/jessica/miniconda3/envs/molecool/bin/python
 cachedir: .pytest_cache
 rootdir: /Users/jessica/lessons/molecool
 collected 11 items                                                                                                                                                        
@@ -1140,7 +1140,7 @@ Change the expected answer to 0.2 in the docstring and re-run the test to get th
 
 ```{code-block} output
 =========================================================================== test session starts ===========================================================================
-platform darwin -- Python 3.10.12, pytest-7.4.2, pluggy-1.3.0 -- /Users/jessica/miniconda3/envs/molecool/bin/python
+platform darwin -- Python 3.11.6, pytest-7.4.2, pluggy-1.3.0 -- /Users/jessica/miniconda3/envs/molecool/bin/python
 cachedir: .pytest_cache
 rootdir: /Users/jessica/lessons/molecool
 collected 11 items                                                                                                                                                        
@@ -1201,7 +1201,7 @@ pytest --cov=molecool
 
 ```{code-block} output
 =========================================================================== test session starts ===========================================================================
-platform darwin -- Python 3.10.12, pytest-7.4.2, pluggy-1.3.0
+platform darwin -- Python 3.11.6, pytest-7.4.2, pluggy-1.3.0
 rootdir: /Users/jessica/lessons/molecool
 plugins: cov-2.8.1
 collected 10 items                                                                                                                                                        
@@ -1209,7 +1209,7 @@ collected 10 items
 molecool/tests/test_measure.py ......                                                                                                                               [ 60%]
 molecool/tests/test_molecule.py ....                                                                                                                                [100%]
 
----------- coverage: platform darwin, python 3.10.12-final-0 -----------
+---------- coverage: platform darwin, Python 3.11.6-final-0 -----------
 Name                      Stmts   Miss  Cover
 ---------------------------------------------
 molecool/__init__.py          9      0   100%

--- a/_episodes/09-CI.md
+++ b/_episodes/09-CI.md
@@ -145,14 +145,14 @@ To see what this means, let's look at our first step.
 
 ```{code-block} CI.yaml 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 ```
 ````
 
 
 This starts our `steps` section. Steps in our workflow are indicated either with the `uses` keyword or with the `name` keyword (will see next).
 If we use `uses,`, we are using a modular step which someone else has written and made available on the GitHub Actions Marketplace.
-It then says that it uses `actions/checkout@v1`.
+It then says that it uses `actions/checkout@v3`.
 This is an action which checks out your project.
 You can see the [documentation](https://github.com/marketplace/actions/checkout) to learn more about this action.
 By specifying that this step uses the checkout action, we don't have to write code to do the checkout ourselves.
@@ -179,18 +179,16 @@ Next, we set up miniconda. This is a common action which many people have to do 
 ````{tab-set-code} 
 
 ```{code-block} CI.yaml 
-    # More info on options: https://github.com/conda-incubator/setup-miniconda
-    - uses: conda-incubator/setup-miniconda@v2
+    # More info on options: https://github.com/marketplace/actions/setup-micromamba
+    - uses: mamba-org/setup-micromamba@v1
       with:
         python-version: ${{ matrix.python-version }}
         environment-file: devtools/conda-envs/test_env.yaml
+        condarc: |
+          channels:
+            - conda-forge
+            - defaults
 
-        channels: conda-forge,defaults
-
-        activate-environment: test
-        auto-update-conda: false
-        auto-activate-base: false
-        show-channel-urls: true
 ```
 ````
 


### PR DESCRIPTION
Made some syntax changes to the files within the `_episodes/` directory to match the newest version of Molssi cookiecutter-cms.

## Minor syntax changes  
- Update tree in terminal output in [01-package-setup.md](https://github.com/sja58429/python-package-best-practices/blob/documentation_2023_update/_episodes/01-package-setup.md) & [05-package-structure.md](https://github.com/sja58429/python-package-best-practices/blob/documentation_2023_update/_episodes/05-package-structure.md)

- Changed ``python3.7/site-packages`` occurrence to ``python3.11/site-packages`` in  [01-package-setup.md](https://github.com/sja58429/python-package-best-practices/blob/documentation_2023_update/_episodes/01-package-setup.md)
- Updated the pytest version output from 3.7.12 to 3.11.6 in [08-testing.md](https://github.com/sja58429/python-package-best-practices/blob/documentation_2023_update/_episodes/08-testing.md)
- checkout@v2 -> checkout@v3 in [09-CI.md](https://github.com/sja58429/python-package-best-practices/blob/documentation_2023_update/_episodes/09-CI.md)

